### PR TITLE
Restructure how content is linked to users

### DIFF
--- a/app/controllers/contents_controller.rb
+++ b/app/controllers/contents_controller.rb
@@ -44,6 +44,6 @@ class ContentsController < ApplicationController
   private
 
   def content_params
-    params.require(:content).permit(:body, :link, :position, :welcome_message)
+    params.require(:content).permit(:body, :link, :position, :welcome_message, :age_in_months)
   end
 end

--- a/app/controllers/contents_controller.rb
+++ b/app/controllers/contents_controller.rb
@@ -44,6 +44,6 @@ class ContentsController < ApplicationController
   private
 
   def content_params
-    params.require(:content).permit(:body, :link, :position, :welcome_message, :age_in_months)
+    params.require(:content).permit(:body, :link, :position, :age_in_months)
   end
 end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,6 +1,6 @@
 class GroupsController < ApplicationController
   def index
-    @groups = Group.order(:age_in_months)
+    @groups = Group.all
   end
 
   def show
@@ -44,6 +44,6 @@ class GroupsController < ApplicationController
   private
 
   def group_params
-    params.require(:group).permit(:name, :age_in_months)
+    params.require(:group).permit(:name)
   end
 end

--- a/app/jobs/send_bulk_message_job.rb
+++ b/app/jobs/send_bulk_message_job.rb
@@ -1,10 +1,8 @@
 class SendBulkMessageJob < ApplicationJob
   queue_as :default
 
-  def perform(users, group)
-    return unless group.present?
-
-    message_jobs = users.map { |user| SendMessageJob.new(user, group) }
+  def perform(users)
+    message_jobs = users.map { |user| SendMessageJob.new(user) }
 
     ActiveJob.perform_all_later(message_jobs)
   end

--- a/app/jobs/send_welcome_message_job.rb
+++ b/app/jobs/send_welcome_message_job.rb
@@ -7,20 +7,31 @@ class SendWelcomeMessageJob < ApplicationJob
     content = Content.find_by(age_in_months: user.child_age_in_months_today, welcome_message: true)
 
     message = if content.present?
-      Message.create do |m|
+      Message.build do |m|
         m.token = m.send(:generate_token)
         m.link = content.link
         m.user = user
         m.body = content.body.gsub("{{link}}", track_link_url(m.token))
       end
     else
-      Message.create do |m|
+      Message.build do |m|
         m.token = m.send(:generate_token)
         m.user = user
         m.body = "Welcome to Tiny Happy People, a programme of weekly texts with fun activities! You'll receive your first activity soon."
       end
     end
 
-    Twilio::Client.new.send_message(message)
+    Twilio::Client.new.send_message(message) if save_user_and_message(user, message, content)
+  end
+
+  private
+
+  def save_user_and_message(user, message, content)
+    ActiveRecord::Base.transaction do
+      user.update(last_content_id: content.id) if content.present?
+      message.save
+    rescue ActiveRecord::RecordInvalid
+      false
+    end
   end
 end

--- a/app/jobs/send_welcome_message_job.rb
+++ b/app/jobs/send_welcome_message_job.rb
@@ -4,34 +4,12 @@ class SendWelcomeMessageJob < ApplicationJob
   queue_as :default
 
   def perform(user)
-    content = Content.find_by(age_in_months: user.child_age_in_months_today, welcome_message: true)
-
-    message = if content.present?
-      Message.build do |m|
-        m.token = m.send(:generate_token)
-        m.link = content.link
-        m.user = user
-        m.body = content.body.gsub("{{link}}", track_link_url(m.token))
-      end
-    else
-      Message.build do |m|
-        m.token = m.send(:generate_token)
-        m.user = user
-        m.body = "Welcome to Tiny Happy People, a programme of weekly texts with fun activities! You'll receive your first activity soon."
-      end
+    message = Message.build do |m|
+      m.token = m.send(:generate_token)
+      m.user = user
+      m.body = Content::WELCOME_MESSAGE
     end
 
-    Twilio::Client.new.send_message(message) if save_user_and_message(user, message, content)
-  end
-
-  private
-
-  def save_user_and_message(user, message, content)
-    ActiveRecord::Base.transaction do
-      user.update(last_content_id: content.id) if content.present?
-      message.save
-    rescue ActiveRecord::RecordInvalid
-      false
-    end
+    Twilio::Client.new.send_message(message) if message.save
   end
 end

--- a/app/jobs/send_welcome_message_job.rb
+++ b/app/jobs/send_welcome_message_job.rb
@@ -4,14 +4,14 @@ class SendWelcomeMessageJob < ApplicationJob
   queue_as :default
 
   def perform(user)
-    group = Group.find_by(age_in_months: user.child_age_in_months_today)
+    content = Content.find_by(age_in_months: user.child_age_in_months_today, welcome_message: true)
 
-    message = if group.present? && group.welcome_message.present?
+    message = if content.present?
       Message.create do |m|
         m.token = m.send(:generate_token)
-        m.link = group.welcome_message.link
+        m.link = content.link
         m.user = user
-        m.body = group.welcome_message.body.gsub("{{link}}", track_link_url(m.token))
+        m.body = content.body.gsub("{{link}}", track_link_url(m.token))
       end
     else
       Message.create do |m|

--- a/app/models/content.rb
+++ b/app/models/content.rb
@@ -4,5 +4,5 @@ class Content < ApplicationRecord
 
   has_many :messages, dependent: :nullify
 
-  validates_presence_of :body, :link
+  validates_presence_of :body, :link, :age_in_months
 end

--- a/app/models/content.rb
+++ b/app/models/content.rb
@@ -5,4 +5,6 @@ class Content < ApplicationRecord
   has_many :messages, dependent: :nullify
 
   validates_presence_of :body, :link, :age_in_months
+
+  WELCOME_MESSAGE = "Hi [Parent], welcome to our programme of weekly texts with fun activities for [Child]’s development. Congrats on starting this amazing journey with your little one!"
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,11 +1,7 @@
 class Group < ApplicationRecord
   has_many :contents, dependent: :destroy
 
-  validates :name, :age_in_months, presence: true
-
-  def welcome_message
-    contents.find_by(welcome_message: true)
-  end
+  validates :name, presence: true
 
   def weekly_content
     contents.where(welcome_message: false)

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -2,8 +2,4 @@ class Group < ApplicationRecord
   has_many :contents, dependent: :destroy
 
   validates :name, presence: true
-
-  def weekly_content
-    contents.where(welcome_message: false)
-  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -84,8 +84,8 @@ class User < ApplicationRecord
       content = Content.find_by(position: i)
       # Last message in series
       return nil if content.nil?
-      # Next message
-      return content if not_seen_content?(content)
+      # Next message that's not a welcome message
+      return content if not_seen_content?(content) && !content.welcome_message?
       i += 1
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -59,7 +59,7 @@ class User < ApplicationRecord
     if had_any_content_before?
       find_next_unseen_content
     else
-      Content.where(age_in_months: child_age_in_months_today, welcome_message: false).min_by(&:position)
+      Content.where(age_in_months: child_age_in_months_today).min_by(&:position)
     end
   end
 
@@ -84,8 +84,8 @@ class User < ApplicationRecord
       content = Content.find_by(position: i)
       # Last message in series
       return nil if content.nil?
-      # Next message that's not a welcome message
-      return content if not_seen_content?(content) && !content.welcome_message?
+      # Next message
+      return content if not_seen_content?(content)
       i += 1
     end
   end

--- a/app/views/contents/_form.html.erb
+++ b/app/views/contents/_form.html.erb
@@ -11,9 +11,5 @@
     <%= form.input :link %>
   </div>
 
-  <div class="mt-3">
-    <%= form.input :welcome_message, label: "This is the welcome message", input_html: { class: "form-checkbox" } %>
-  </div>
-
   <%= form.submit (action_name == "edit" ? "Update" : "Create"), class: "btn btn-primary mt-5 bg-purple-600 text-white w-full" %>
 <% end %>

--- a/app/views/contents/_form.html.erb
+++ b/app/views/contents/_form.html.erb
@@ -4,6 +4,10 @@
   </div>
 
   <div class="mt-3">
+    <%= form.input :age_in_months, wrapper_html: { class: "w-1/2" } %>
+  </div>
+
+  <div class="mt-3">
     <%= form.input :link %>
   </div>
 

--- a/app/views/groups/_form.html.erb
+++ b/app/views/groups/_form.html.erb
@@ -3,9 +3,5 @@
     <%= form.input :name %>
   </div>
 
-  <div class="mt-3">
-    <%= form.input :age_in_months %>
-  </div>
-
   <%= form.submit (action_name == "edit" ? "Update" : "Create"), class: "btn btn-primary mt-5 bg-purple-600 text-white w-full" %>
 <% end %>

--- a/app/views/groups/index.html.erb
+++ b/app/views/groups/index.html.erb
@@ -9,7 +9,6 @@
       <thead>
         <tr class="px-4 py-4 bg-purple-300 text-left">
           <th class="p-4 w-3/4">Content group name</th>
-          <th class="p-4 w-3/4">Child age</th>
           <th class="p-4 w-1/5">No. of messages</th>
           <th>&nbsp</th>
         </tr>
@@ -18,7 +17,6 @@
         <% @groups.each do |group| %>
           <tr class="border-b-2">
             <td class="p-4"><%= link_to group.name, group, class: "underline hover:no-underline" %></td>
-            <td class="p-4"><%= group.age_in_months %> months</td>
             <td class="p-4"><%= group.contents.size %></td>
             <td class="p-4">
               <%= link_to "Edit", edit_group_path(group), class: "underline hover:no-underline" %>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -12,8 +12,9 @@
       <thead>
         <tr class="px-4 py-4 bg-purple-300 text-left">
           <th class="p-4"></th>
-          <th class="p-4 w-3/5">Body</th>
-          <th class="p-4 w-2/5">Link</th>
+          <th class="p-4 w-6/12">Body</th>
+          <th class="p-4 w-1/12">Age</th>
+          <th class="p-4 w-5/12">Link</th>
           <th>&nbsp</th>
         </tr>
       </thead>
@@ -30,6 +31,9 @@
                 <span class="text-sm text-gray-500">Welcome message</span><br>
               <% end %>
               <%= content.body %>
+            </td>
+            <td class="p-4">
+              <%= content.age_in_months %>
             </td>
             <td class="p-4"><%= content.link %></td>
             <td class="p-4">

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -22,9 +22,7 @@
         <% @group.contents.order(:position).each do |content| %>
           <tr class="border-b-2" data-sortable-update-url="<%= update_position_path(content) %>">
             <td class="p-4">
-              <% unless content.welcome_message? %>
-                <svg class="cursor-grab" width="20px" height="20px" stroke-width="1.5" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" color="#ccc"><path d="M3 5H21" stroke="#000000" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path><path d="M3 12H21" stroke="#000000" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path><path d="M3 19H21" stroke="#000000" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path></svg>
-              <% end %>
+              <svg class="cursor-grab" width="20px" height="20px" stroke-width="1.5" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" color="#ccc"><path d="M3 5H21" stroke="#000000" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path><path d="M3 12H21" stroke="#000000" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path><path d="M3 19H21" stroke="#000000" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path></svg>
             </td>
             <td class="p-4">
               <% if content.welcome_message? %>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -25,9 +25,6 @@
               <svg class="cursor-grab" width="20px" height="20px" stroke-width="1.5" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" color="#ccc"><path d="M3 5H21" stroke="#000000" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path><path d="M3 12H21" stroke="#000000" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path><path d="M3 19H21" stroke="#000000" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"></path></svg>
             </td>
             <td class="p-4">
-              <% if content.welcome_message? %>
-                <span class="text-sm text-gray-500">Welcome message</span><br>
-              <% end %>
               <%= content.body %>
             </td>
             <td class="p-4">

--- a/db/migrate/20241205095730_add_last_content_to_user.rb
+++ b/db/migrate/20241205095730_add_last_content_to_user.rb
@@ -1,0 +1,5 @@
+class AddLastContentToUser < ActiveRecord::Migration[7.2]
+  def change
+    add_reference :users, :last_content, foreign_key: {to_table: :contents}
+  end
+end

--- a/db/migrate/20241205100911_remove_age_from_group.rb
+++ b/db/migrate/20241205100911_remove_age_from_group.rb
@@ -1,0 +1,12 @@
+class RemoveAgeFromGroup < ActiveRecord::Migration[7.2]
+  def change
+    add_column :contents, :age_in_months, :integer
+
+    Content.find_each do |content|
+      content.update(age_in_months: content.group.age_in_months)
+    end
+
+    remove_column :groups, :age_in_months, :integer
+    change_column_null :contents, :age_in_months, false
+  end
+end

--- a/db/migrate/20241206110738_remove_welcome_message_from_content.rb
+++ b/db/migrate/20241206110738_remove_welcome_message_from_content.rb
@@ -1,0 +1,5 @@
+class RemoveWelcomeMessageFromContent < ActiveRecord::Migration[8.0]
+  def change
+    remove_column :contents, :welcome_message, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -97,6 +97,7 @@ ActiveRecord::Schema[8.0].define(version: 2024_12_05_140053) do
     t.bigint "group_id"
     t.integer "position", null: false
     t.boolean "welcome_message", default: false
+    t.integer "age_in_months", null: false
     t.index ["group_id", "position"], name: "index_contents_on_group_id_and_position", unique: true
     t.index ["group_id"], name: "index_contents_on_group_id"
   end
@@ -118,7 +119,6 @@ ActiveRecord::Schema[8.0].define(version: 2024_12_05_140053) do
 
   create_table "groups", force: :cascade do |t|
     t.string "name", null: false
-    t.integer "age_in_months", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
@@ -136,14 +136,13 @@ ActiveRecord::Schema[8.0].define(version: 2024_12_05_140053) do
     t.bigint "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "content_id"
     t.string "message_sid"
     t.string "status"
     t.datetime "sent_at"
     t.string "token", null: false
     t.string "link"
     t.datetime "clicked_at"
-    t.index ["content_id"], name: "index_messages_on_content_id"
+    t.bigint "content_id"
     t.index ["token"], name: "index_messages_on_token", unique: true
   end
 
@@ -169,9 +168,11 @@ ActiveRecord::Schema[8.0].define(version: 2024_12_05_140053) do
     t.datetime "restart_at"
     t.integer "adjust_amount", default: 0
     t.datetime "nudged_at"
+    t.bigint "last_content_id"
+    t.index ["last_content_id"], name: "index_users_on_last_content_id"
   end
 
   add_foreign_key "clicks", "pages"
   add_foreign_key "interests", "users"
-  add_foreign_key "messages", "contents"
+  add_foreign_key "users", "contents", column: "last_content_id"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2024_12_05_140053) do
+ActiveRecord::Schema[8.0].define(version: 2024_12_06_110738) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -96,7 +96,6 @@ ActiveRecord::Schema[8.0].define(version: 2024_12_05_140053) do
     t.string "link"
     t.bigint "group_id"
     t.integer "position", null: false
-    t.boolean "welcome_message", default: false
     t.integer "age_in_months", null: false
     t.index ["group_id", "position"], name: "index_contents_on_group_id_and_position", unique: true
     t.index ["group_id"], name: "index_contents_on_group_id"
@@ -136,13 +135,14 @@ ActiveRecord::Schema[8.0].define(version: 2024_12_05_140053) do
     t.bigint "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "content_id"
     t.string "message_sid"
     t.string "status"
     t.datetime "sent_at"
     t.string "token", null: false
     t.string "link"
     t.datetime "clicked_at"
-    t.bigint "content_id"
+    t.index ["content_id"], name: "index_messages_on_content_id"
     t.index ["token"], name: "index_messages_on_token", unique: true
   end
 
@@ -174,5 +174,6 @@ ActiveRecord::Schema[8.0].define(version: 2024_12_05_140053) do
 
   add_foreign_key "clicks", "pages"
   add_foreign_key "interests", "users"
+  add_foreign_key "messages", "contents"
   add_foreign_key "users", "contents", column: "last_content_id"
 end

--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -3,12 +3,8 @@ namespace :scheduler do
   task send_morning_message: :environment do
     (next unless Date.today.wday == ENV.fetch("WEEKLY_MESSAGE_DAY").to_i) if ENV.fetch("SET_WEEKLY") == "true"
 
-    User.contactable.wants_morning_message.group_by(&:adjusted_child_age_in_months_today).each do |age, users|
-      group = Group.find_by(age_in_months: age)
-
-      next unless group
-
-      SendBulkMessageJob.perform_later(users, group)
+    User.contactable.wants_morning_message.find_in_batches do |users|
+      SendBulkMessageJob.perform_later(users)
     end
   end
 
@@ -16,12 +12,8 @@ namespace :scheduler do
   task send_afternoon_message: :environment do
     (next unless Date.today.wday == ENV.fetch("WEEKLY_MESSAGE_DAY").to_i) if ENV.fetch("SET_WEEKLY") == "true"
 
-    User.contactable.wants_afternoon_message.group_by(&:adjusted_child_age_in_months_today).each do |age, users|
-      group = Group.find_by(age_in_months: age)
-
-      next unless group
-
-      SendBulkMessageJob.perform_later(users, group)
+    User.contactable.wants_afternoon_message.find_in_batches do |users|
+      SendBulkMessageJob.perform_later(users)
     end
   end
 
@@ -29,12 +21,8 @@ namespace :scheduler do
   task send_evening_message: :environment do
     (next unless Date.today.wday == ENV.fetch("WEEKLY_MESSAGE_DAY").to_i) if ENV.fetch("SET_WEEKLY") == "true"
 
-    User.contactable.wants_evening_message.group_by(&:adjusted_child_age_in_months_today).each do |age, users|
-      group = Group.find_by(age_in_months: age)
-
-      next unless group
-
-      SendBulkMessageJob.perform_later(users, group)
+    User.contactable.wants_evening_message.find_in_batches do |users|
+      SendBulkMessageJob.perform_later(users)
     end
   end
 
@@ -42,12 +30,8 @@ namespace :scheduler do
   task send_no_timing_preference_message: :environment do
     (next unless Date.today.wday == ENV.fetch("WEEKLY_MESSAGE_DAY").to_i) if ENV.fetch("SET_WEEKLY") == "true"
 
-    User.contactable.no_preference_message.group_by(&:adjusted_child_age_in_months_today).each do |age, users|
-      group = Group.find_by(age_in_months: age)
-
-      next unless group
-
-      SendBulkMessageJob.perform_later(users, group)
+    User.contactable.no_preference_message.find_in_batches do |users|
+      SendBulkMessageJob.perform_later(users)
     end
   end
 

--- a/test/factories/content.rb
+++ b/test/factories/content.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :content do
     body { "Sample Body" }
     link { "www.example.com" }
+    age_in_months { 18 }
     sequence(:position) { |n| n }
 
     group

--- a/test/factories/group.rb
+++ b/test/factories/group.rb
@@ -1,6 +1,5 @@
 FactoryBot.define do
   factory :group do
-    name { "Content for 18 month olds" }
-    age_in_months { 18 }
+    name { "Group" }
   end
 end

--- a/test/jobs/send_bulk_message_job_test.rb
+++ b/test/jobs/send_bulk_message_job_test.rb
@@ -5,20 +5,11 @@ class SendBulkMessageJobTest < ActiveSupport::TestCase
 
   test "#perform creates jobs to send messages to users" do
     users = create_list(:user, 3, child_birthday: 3.months.ago)
-    group = create(:group, age_in_months: 3)
+    group = create(:group)
     create(:content, group:)
 
     assert_enqueued_jobs 3 do
-      SendBulkMessageJob.perform_now(users, group)
-    end
-  end
-
-  test "#perform does not create jobs if group is not present" do
-    users = create_list(:user, 3, child_birthday: 3.months.ago)
-    group = nil
-
-    assert_no_enqueued_jobs do
-      SendBulkMessageJob.perform_now(users, group)
+      SendBulkMessageJob.perform_now(users)
     end
   end
 end

--- a/test/jobs/send_message_job_test.rb
+++ b/test/jobs/send_message_job_test.rb
@@ -5,48 +5,64 @@ class SendMessageJobTest < ActiveSupport::TestCase
   include Rails.application.routes.url_helpers
 
   test "#perform sends messages with default content" do
-    user = create(:user)
-    group = create(:group, age_in_months: user.child_age_in_months_today)
-    content = create(:content, group:, body: "here is a link: {{link}}")
+    content = create(:content, body: "here is a link: {{link}}")
+    content2 = create(:content, group: content.group, body: "here is a link: {{link}}")
+    user = create(:user, last_content_id: content.id)
 
     Message.any_instance.stubs(:generate_token).returns("123")
 
-    stub_successful_twilio_call(content.body.gsub("{{link}}", track_link_url("123")), user)
+    stub_successful_twilio_call(content2.body.gsub("{{link}}", track_link_url("123")), user)
 
-    SendMessageJob.new.perform(user, group)
+    SendMessageJob.new.perform(user)
 
     assert_equal 1, Message.count
-    assert_equal content, Message.last.content
+    assert_equal content2, Message.last.content
     assert_match(/m\/123/, Message.last.body)
+    assert_equal content2.id, user.reload.last_content_id
   end
 
   test "#perform does not send message if no appropriate content available" do
     assert_no_changes -> { Message.count } do
-      SendMessageJob.new.perform(create(:user), create(:group))
+      SendMessageJob.new.perform(create(:user))
     end
   end
 
   test "#perform does not send message if user already has the same message" do
     user = create(:user)
-    group = create(:group, age_in_months: user.child_age_in_months_today)
-    content = create(:content, group: group)
+    group = create(:group)
+    content = create(:content, group:)
 
-    create(:message, user: user, content: content)
+    create(:message, user:, content:)
 
     assert_no_changes -> { Message.count } do
-      SendMessageJob.new.perform(user, group)
+      SendMessageJob.new.perform(user)
     end
   end
 
   test "#perform does not send message if user has had a message this week" do
     user = create(:user)
-    group = create(:group, age_in_months: user.child_age_in_months_today)
-    content = create(:content, group: group)
+    group = create(:group)
+    content = create(:content, group:)
 
     create(:message, user: user, content: content, created_at: 1.day.ago)
 
     assert_no_changes -> { Message.count } do
-      SendMessageJob.new.perform(user, group)
+      SendMessageJob.new.perform(user)
     end
+  end
+
+  test "#perform does not send message if user fails to update" do
+    content = create(:content, body: "here is a link: {{link}}")
+    create(:content, group: content.group, body: "here is a link: {{link}}")
+    user = create(:user, last_content_id: content.id)
+
+    Message.any_instance.stubs(:generate_token).returns("123")
+    User.any_instance.stubs(:update).raises(ActiveRecord::RecordInvalid)
+
+    assert_no_changes -> { Message.count } do
+      SendMessageJob.new.perform(user)
+    end
+
+    assert_equal content.id, user.reload.last_content_id
   end
 end

--- a/test/jobs/send_welcome_message_job_test.rb
+++ b/test/jobs/send_welcome_message_job_test.rb
@@ -6,53 +6,12 @@ class SendWelcomeMessageJobTest < ActiveSupport::TestCase
 
   test "#perform sends message with default content" do
     user = create(:user, child_birthday: 18.months.ago)
-    group = create(:group)
-    content = create(:content, group:, welcome_message: true, link: "https://example.com", body: "Hi, {{link}}")
-    create(:content, group:, welcome_message: false, link: "https://example.com")
 
-    Message.any_instance.stubs(:generate_token).returns("123")
-
-    stub_successful_twilio_call(content.body.gsub("{{link}}", track_link_url("123")), user)
+    stub_successful_twilio_call(Content::WELCOME_MESSAGE, user)
 
     SendWelcomeMessageJob.new.perform(user)
 
     assert_equal 1, Message.count
-    assert_match(/m\/123/, Message.last.body)
-    assert_equal "https://example.com", Message.last.link
-    assert_equal user.reload.last_content_id, content.id
-  end
-
-  test "#perform sends message with no link if there isn't appropriate content" do
-    user = create(:user, child_birthday: 25.months.ago)
-
-    Message.any_instance.stubs(:generate_token).returns("123")
-
-    message = "Welcome to Tiny Happy People, a programme of weekly texts with fun activities! You'll receive your first activity soon."
-
-    stub_successful_twilio_call(message, user)
-
-    SendWelcomeMessageJob.new.perform(user)
-
-    assert_equal 1, Message.count
-    assert_nil Message.last.link
-    assert_nil user.reload.last_content_id
-  end
-
-  test "#perform sends message with no link if there isn't a welcome message" do
-    user = create(:user, child_birthday: 18.months.ago)
-    group = create(:group)
-    create(:content, group:, welcome_message: false, link: "https://example.com")
-
-    Message.any_instance.stubs(:generate_token).returns("123")
-
-    message = "Welcome to Tiny Happy People, a programme of weekly texts with fun activities! You'll receive your first activity soon."
-
-    stub_successful_twilio_call(message, user)
-
-    SendWelcomeMessageJob.new.perform(user)
-
-    assert_equal 1, Message.count
-    assert_nil Message.last.link
-    assert_nil user.reload.last_content_id
+    assert_match(Content::WELCOME_MESSAGE, Message.last.body)
   end
 end

--- a/test/jobs/send_welcome_message_job_test.rb
+++ b/test/jobs/send_welcome_message_job_test.rb
@@ -19,6 +19,7 @@ class SendWelcomeMessageJobTest < ActiveSupport::TestCase
     assert_equal 1, Message.count
     assert_match(/m\/123/, Message.last.body)
     assert_equal "https://example.com", Message.last.link
+    assert_equal user.reload.last_content_id, content.id
   end
 
   test "#perform sends message with no link if there isn't appropriate content" do
@@ -34,6 +35,7 @@ class SendWelcomeMessageJobTest < ActiveSupport::TestCase
 
     assert_equal 1, Message.count
     assert_nil Message.last.link
+    assert_nil user.reload.last_content_id
   end
 
   test "#perform sends message with no link if there isn't a welcome message" do
@@ -51,5 +53,6 @@ class SendWelcomeMessageJobTest < ActiveSupport::TestCase
 
     assert_equal 1, Message.count
     assert_nil Message.last.link
+    assert_nil user.reload.last_content_id
   end
 end

--- a/test/jobs/send_welcome_message_job_test.rb
+++ b/test/jobs/send_welcome_message_job_test.rb
@@ -6,7 +6,7 @@ class SendWelcomeMessageJobTest < ActiveSupport::TestCase
 
   test "#perform sends message with default content" do
     user = create(:user, child_birthday: 18.months.ago)
-    group = create(:group, age_in_months: 18)
+    group = create(:group)
     content = create(:content, group:, welcome_message: true, link: "https://example.com", body: "Hi, {{link}}")
     create(:content, group:, welcome_message: false, link: "https://example.com")
 
@@ -38,7 +38,7 @@ class SendWelcomeMessageJobTest < ActiveSupport::TestCase
 
   test "#perform sends message with no link if there isn't a welcome message" do
     user = create(:user, child_birthday: 18.months.ago)
-    group = create(:group, age_in_months: 18)
+    group = create(:group)
     create(:content, group:, welcome_message: false, link: "https://example.com")
 
     Message.any_instance.stubs(:generate_token).returns("123")

--- a/test/lib/scheduler_test.rb
+++ b/test/lib/scheduler_test.rb
@@ -14,8 +14,7 @@ class SchedulerTest < ActiveSupport::TestCase
   end
 
   test "send_morning_message" do
-    group = create(:group, age_in_months: 18)
-    create(:content, group:)
+    create(:content)
     create(:user, timing: "morning")
 
     assert_enqueued_with(job: SendBulkMessageJob) do
@@ -24,8 +23,7 @@ class SchedulerTest < ActiveSupport::TestCase
   end
 
   test "send_afternoon_message" do
-    group = create(:group, age_in_months: 18)
-    create(:content, group:)
+    create(:content)
     create(:user, timing: "afternoon")
 
     assert_enqueued_with(job: SendBulkMessageJob) do
@@ -34,8 +32,7 @@ class SchedulerTest < ActiveSupport::TestCase
   end
 
   test "send_evening_message" do
-    group = create(:group, age_in_months: 18)
-    create(:content, group:)
+    create(:content)
     create(:user, timing: "evening")
 
     assert_enqueued_with(job: SendBulkMessageJob) do
@@ -44,8 +41,7 @@ class SchedulerTest < ActiveSupport::TestCase
   end
 
   test "send_no_timing_preference_message" do
-    group = create(:group, age_in_months: 18)
-    create(:content, group:)
+    create(:content)
     create(:user, timing: "no_preference")
 
     assert_enqueued_with(job: SendBulkMessageJob) do
@@ -54,8 +50,7 @@ class SchedulerTest < ActiveSupport::TestCase
   end
 
   test "send_no_timing_preference_message for users with no timing set" do
-    group = create(:group, age_in_months: 18)
-    create(:content, group:)
+    create(:content)
     create(:user, timing: nil)
 
     assert_enqueued_with(job: SendBulkMessageJob) do
@@ -68,21 +63,6 @@ class SchedulerTest < ActiveSupport::TestCase
 
     assert_no_enqueued_jobs do
       Rake::Task["scheduler:send_morning_message"].execute
-    end
-  end
-
-  test "no job enqueued if there is no appropriate group" do
-    create(:user, timing: "morning")
-    create(:user, timing: "afternoon")
-    create(:user, timing: "evening")
-    create(:user, timing: "no_preference")
-    create(:user, timing: nil)
-
-    assert_no_enqueued_jobs do
-      Rake::Task["scheduler:send_morning_message"].execute
-      Rake::Task["scheduler:send_afternoon_message"].execute
-      Rake::Task["scheduler:send_evening_message"].execute
-      Rake::Task["scheduler:send_no_timing_preference_message"].execute
     end
   end
 
@@ -132,8 +112,7 @@ class SchedulerTest < ActiveSupport::TestCase
   test "doesn't run unless it's the right day" do
     travel_to_tuesday
 
-    group = create(:group, age_in_months: 18)
-    create(:content, group:)
+    create(:content)
     create(:user, timing: "morning")
 
     assert_no_enqueued_jobs do
@@ -145,8 +124,7 @@ class SchedulerTest < ActiveSupport::TestCase
     ENV["SET_WEEKLY"] = "false"
     travel_to_tuesday
 
-    group = create(:group, age_in_months: 18)
-    create(:content, group:)
+    create(:content)
     create(:user, timing: "morning")
 
     assert_enqueued_with(job: SendBulkMessageJob) do

--- a/test/models/group_test.rb
+++ b/test/models/group_test.rb
@@ -10,19 +10,11 @@ class GroupTest < ActiveSupport::TestCase
   end
 
   test("name required") { assert_present(:name) }
-  test("age_in_months required") { assert_present(:age_in_months) }
 
   test "#weekly_content" do
     weekly_content = create(:content, group: @subject)
     create(:content, group: @subject, welcome_message: true)
 
     assert_equal [weekly_content], @subject.weekly_content
-  end
-
-  test "#welcome_message" do
-    welcome_message = create(:content, group: @subject, welcome_message: true)
-    create(:content, group: @subject, welcome_message: false)
-
-    assert_equal welcome_message, @subject.welcome_message
   end
 end

--- a/test/models/group_test.rb
+++ b/test/models/group_test.rb
@@ -10,11 +10,4 @@ class GroupTest < ActiveSupport::TestCase
   end
 
   test("name required") { assert_present(:name) }
-
-  test "#weekly_content" do
-    weekly_content = create(:content, group: @subject)
-    create(:content, group: @subject, welcome_message: true)
-
-    assert_equal [weekly_content], @subject.weekly_content
-  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -176,6 +176,16 @@ class UserTest < ActiveSupport::TestCase
     assert_equal @subject.next_content, content3
   end
 
+  test "#next_content does not return welcome messages" do
+    group = create(:group)
+    content1 = create(:content, group:, position: 1)
+    create(:content, group:, position: 2, welcome_message: true)
+    content3 = create(:content, group:, position: 3)
+    @subject.update(last_content_id: content1.id)
+
+    assert_equal @subject.next_content, content3
+  end
+
   test "#had_content_this_week? method returns true if user has had content" do
     user = create(:user)
     content = create(:content)

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -127,7 +127,6 @@ class UserTest < ActiveSupport::TestCase
 
   test "#next_content method returns next ranked content for age group" do
     group = create(:group)
-    create(:content, group:, welcome_message: true)
     content1 = create(:content, group:, position: 1)
     content2 = create(:content, group:, position: 2)
     create(:content, group:, position: 3)
@@ -149,17 +148,7 @@ class UserTest < ActiveSupport::TestCase
     group = create(:group)
     content = create(:content, group:, position: 1, age_in_months: 18)
     create(:content, group:, position: 2, age_in_months: 18)
-    create(:content, group:, position: 3, age_in_months: 18)
-
-    assert_equal @subject.next_content, content
-  end
-
-  test "#next_content does not return the welcome message if user has not had content before" do
-    group = create(:group)
-    create(:content, group:, position: 1, welcome_message: true)
-    content = create(:content, group:, position: 2, age_in_months: 18)
-    create(:content, group:, position: 3, age_in_months: 18)
-    create(:content, group:, position: 4, age_in_months: 18)
+    create(:content, group:, position: 3, age_in_months: 19)
 
     assert_equal @subject.next_content, content
   end
@@ -171,16 +160,6 @@ class UserTest < ActiveSupport::TestCase
     content2 = create(:content, group:, position: 2)
     content3 = create(:content, group:, position: 3)
     create(:message, user: @subject, content: content2)
-    @subject.update(last_content_id: content1.id)
-
-    assert_equal @subject.next_content, content3
-  end
-
-  test "#next_content does not return welcome messages" do
-    group = create(:group)
-    content1 = create(:content, group:, position: 1)
-    create(:content, group:, position: 2, welcome_message: true)
-    content3 = create(:content, group:, position: 3)
     @subject.update(last_content_id: content1.id)
 
     assert_equal @subject.next_content, content3

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -126,24 +126,54 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test "#next_content method returns next ranked content for age group" do
-    group = create(:group, age_in_months: @subject.child_age_in_months_today)
+    group = create(:group)
     create(:content, group:, welcome_message: true)
     content1 = create(:content, group:, position: 1)
     content2 = create(:content, group:, position: 2)
-    create(:message, content: content1, user: @subject)
+    create(:content, group:, position: 3)
+    @subject.update(last_content_id: content1.id)
 
-    assert_equal @subject.next_content(group), content2
+    assert_equal @subject.next_content, content2
   end
 
   test "#next_content method returns nothing if no appropriate content" do
-    group = create(:group, age_in_months: @subject.child_age_in_months_today)
-    create(:content, group:, welcome_message: true)
+    group = create(:group)
+    create(:content, group:, position: 1)
+    content2 = create(:content, group:, position: 2)
+    @subject.update(last_content_id: content2.id)
+
+    assert_nil @subject.next_content
+  end
+
+  test "#next_content finds appropriate content if user has not had content before" do
+    group = create(:group)
+    content = create(:content, group:, position: 1, age_in_months: 18)
+    create(:content, group:, position: 2, age_in_months: 18)
+    create(:content, group:, position: 3, age_in_months: 18)
+
+    assert_equal @subject.next_content, content
+  end
+
+  test "#next_content does not return the welcome message if user has not had content before" do
+    group = create(:group)
+    create(:content, group:, position: 1, welcome_message: true)
+    content = create(:content, group:, position: 2, age_in_months: 18)
+    create(:content, group:, position: 3, age_in_months: 18)
+    create(:content, group:, position: 4, age_in_months: 18)
+
+    assert_equal @subject.next_content, content
+  end
+
+  test "#next_content does not return content that the user has already seen" do
+    # This is in case the content order has been switched around by the admins
+    group = create(:group)
     content1 = create(:content, group:, position: 1)
     content2 = create(:content, group:, position: 2)
-    create(:message, content: content1, user: @subject)
-    create(:message, content: content2, user: @subject)
+    content3 = create(:content, group:, position: 3)
+    create(:message, user: @subject, content: content2)
+    @subject.update(last_content_id: content1.id)
 
-    assert_nil @subject.next_content(group)
+    assert_equal @subject.next_content, content3
   end
 
   test "#had_content_this_week? method returns true if user has had content" do

--- a/test/system/contents_test.rb
+++ b/test/system/contents_test.rb
@@ -23,25 +23,6 @@ class ContentsTest < ApplicationSystemTestCase
     assert_text "New content"
   end
 
-  test "creating new content with welcome message" do
-    sign_in
-    visit group_path(@group)
-
-    assert_text @group.name
-
-    click_on "Add new message"
-
-    fill_in "Body", with: "New content"
-    fill_in "Link", with: "www.example.com"
-    fill_in "Age in months", with: "18"
-    check "This is the welcome message"
-    click_on "Create"
-
-    within("tr", text: "New content") do
-      assert_text "Welcome message"
-    end
-  end
-
   test "shows errors" do
     create(:content, body: "Old Content", group: @group)
 

--- a/test/system/contents_test.rb
+++ b/test/system/contents_test.rb
@@ -16,6 +16,7 @@ class ContentsTest < ApplicationSystemTestCase
 
     fill_in "Body", with: "New content"
     fill_in "Link", with: "www.example.com"
+    fill_in "Age in months", with: "18"
     click_on "Create"
 
     assert_text "Content for message was successfully created"
@@ -32,6 +33,7 @@ class ContentsTest < ApplicationSystemTestCase
 
     fill_in "Body", with: "New content"
     fill_in "Link", with: "www.example.com"
+    fill_in "Age in months", with: "18"
     check "This is the welcome message"
     click_on "Create"
 
@@ -52,6 +54,7 @@ class ContentsTest < ApplicationSystemTestCase
 
     assert_field_has_errors("Body")
     assert_field_has_errors("Link")
+    assert_field_has_errors("Age in months")
   end
 
   test "updating content" do

--- a/test/system/groups_test.rb
+++ b/test/system/groups_test.rb
@@ -12,7 +12,6 @@ class GroupsTest < ApplicationSystemTestCase
     click_on "Create content group"
 
     fill_in "Name", with: "Default content"
-    fill_in "Age in months", with: "17"
     click_on "Create"
 
     assert_text "Content group successfully created"
@@ -28,7 +27,6 @@ class GroupsTest < ApplicationSystemTestCase
     click_on "Create"
 
     assert_field_has_errors("Name")
-    assert_field_has_errors("Age in months")
   end
 
   test "updating a group" do

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -15,8 +15,7 @@ class UsersTest < ApplicationSystemTestCase
     check "Would you like to be added to a Slack channel with other parents to discuss the programme?"
     check "I accept the terms of service and privacy policy"
 
-    message = "Welcome to Tiny Happy People, a programme of weekly texts with fun activities! You'll receive your first activity soon."
-    stub_successful_twilio_call(message, User.new(phone_number: "+447444930200"))
+    stub_successful_twilio_call(Content::WELCOME_MESSAGE, User.new(phone_number: "+447444930200"))
 
     within("#sign-up-form") do
       click_on "Sign up"
@@ -35,7 +34,7 @@ class UsersTest < ApplicationSystemTestCase
     assert_text "ABC123"
     assert_text "Does have family support"
     assert_text "On Slack"
-    assert_text "Welcome to Tiny Happy People, a programme of weekly texts with fun activities!"
+    assert_text Content::WELCOME_MESSAGE
   end
 
   test "form shows errors" do


### PR DESCRIPTION
De-normalize the database to store the last content that users received on the user. This makes it easier to know what to send the user next, and reduces the reliance on their age in months. This was causing issues where the child would turn a month older at the beginning of each month, and depending on when they had signed up it meant they were missing content.