### PR TITLE
Restrict sign up numbers

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -24,6 +24,10 @@ class UsersController < ApplicationController
   end
 
   def create
+    if User.not_finished_content.count == 2001
+      return redirect_to root_path, notice: "Thank you for your interest. Due to overwhelming demand, we've reached our maximum signup capacity for now. Please check back in in a few months"
+    end
+
     @user = User.new(user_params)
 
     @user.terms_agreed_at = Time.now if user_params[:terms_agreed_at] == "1"

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -50,6 +50,9 @@ class User < ApplicationRecord
       .group("users.id")
       .having("COUNT(*) = 2")
   }
+  scope :not_finished_content, -> {
+    where.not(id: Message.select(:user_id).where(content_id: Content.order(:position).last&.id))
+  }
 
   attribute :hour_preference,
     morning: "morning",

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -1,6 +1,11 @@
 <div class="md:mt-8 w-full">
   <%= turbo_frame_tag "form" do %>
     <%= simple_form_for @user, anchor: "sign-up-form"  do |form| %>
+      <% if notice %>
+        <p class="border border-blue-500 bg-blue-50 text-blue-900 p-3 mb-8">
+          <%= notice %>
+        </p>
+      <% end %>
       <div class="flex justify-between gap-4">
         <%= form.input :first_name, wrapper_html: { class: "w-1/2" } %>
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -145,6 +145,31 @@ class UserTest < ActiveSupport::TestCase
     assert_equal User.received_two_messages, [user1]
   end
 
+  test "not_finished_content scope" do
+    group = create(:group)
+    content1 = create(:content, position: 1, group:)
+    content2 = create(:content, position: 2, group:)
+    content3 = create(:content, position: 3, group:)
+
+    create(:message, user: @subject, content: content1)
+
+    user1 = create(:user)
+
+    user2 = create(:user)
+    create(:message, user: user2, content: content1)
+    create(:message, user: user2, content: content2)
+
+    user3 = create(:user)
+    create(:message, user: user3, content: content1)
+    create(:message, user: user3, content: content2)
+    create(:message, user: user3, content: content3)
+
+    assert_equal 3, User.not_finished_content.length
+    assert_includes User.not_finished_content, @subject
+    assert_includes User.not_finished_content, user1
+    assert_includes User.not_finished_content, user2
+  end
+
   test "full_name method" do
     user = create(:user, first_name: "John", last_name: "Doe")
 

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -40,6 +40,16 @@ class UsersTest < ApplicationSystemTestCase
     assert_equal "Polish", User.last.new_language_preference
   end
 
+  test "User can't sign up if max capacity reached" do
+    create_list(:user, 2001)
+
+    visit new_user_path
+
+    sign_up
+
+    assert_text "Thank you for your interest. Due to overwhelming demand, we've reached our maximum signup capacity for now. Please check back in in a few months"
+  end
+
   test "user can skip non-essential form fields" do
     visit new_user_path
 


### PR DESCRIPTION
Pre social media push, restrict numbers of sign ups just in case