### PR TITLE
Expand child age validation range

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,7 +8,7 @@ class User < ApplicationRecord
 
   validates :phone_number, :first_name, :last_name, :child_birthday, :terms_agreed_at, :postcode, presence: true
   validates_uniqueness_of :phone_number
-  validates :child_birthday, inclusion: {in: ((Date.today - 24.months)...(Date.today - 3.months))}
+  validates :child_birthday, inclusion: {in: ((Date.today - 27.months)...(Date.today - 3.months))}
 
   phony_normalize :phone_number, default_country_code: "UK"
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -22,8 +22,8 @@ class UserTest < ActiveSupport::TestCase
   test("last_name required") { assert_present(:last_name) }
   test("child_birthday required") { assert_present(:child_birthday) }
 
-  test "child_birthday is within the last 24 months" do
-    @subject.child_birthday = Time.now - 25.months
+  test "child_birthday is within the last 27 months" do
+    @subject.child_birthday = Time.now - 28.months
     assert_not @subject.valid?
 
     @subject.child_birthday = Time.now + 1.month


### PR DESCRIPTION
Users who had children older than 24 months weren't valid when sending texts. Probable fix coming later to work out what to do about sign up