### PR TITLE
Correct logic for updating user in sending message

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -12,7 +12,7 @@ class MessagesController < ApplicationController
       message_sid = params["MessageSid"]
       status = params["MessageStatus"]
 
-      Message.find_by(message_sid:).update(status:, sent_at: Time.now)
+      Message.find_by(message_sid:)&.update(status:, sent_at: Time.now)
     end
   end
 

--- a/app/jobs/send_message_job.rb
+++ b/app/jobs/send_message_job.rb
@@ -25,8 +25,8 @@ class SendMessageJob < ApplicationJob
 
   def save_user_and_message(user, message, content)
     ActiveRecord::Base.transaction do
-      user.update(last_content_id: content.id)
-      message.save
+      user.update!(last_content_id: content.id)
+      message.save!
     rescue ActiveRecord::RecordInvalid
       false
     end

--- a/test/jobs/send_message_job_test.rb
+++ b/test/jobs/send_message_job_test.rb
@@ -74,10 +74,10 @@ class SendMessageJobTest < ActiveSupport::TestCase
   test "#perform does not send message if user fails to update" do
     content = create(:content, body: "here is a link: {{link}}")
     create(:content, group: content.group, body: "here is a link: {{link}}")
-    user = create(:user, last_content_id: content.id)
+    user = build(:user, last_content_id: content.id, child_birthday: 3.years.ago)
+    user.save(validate: false)
 
     Message.any_instance.stubs(:generate_token).returns("123")
-    User.any_instance.stubs(:update).raises(ActiveRecord::RecordInvalid)
 
     assert_no_changes -> { Message.count } do
       SendMessageJob.new.perform(user)


### PR DESCRIPTION
Before, the raise wasn't being triggered so messages were still being sent