### PR TITLE
Get feedback from users opting out

### DIFF
--- a/app/jobs/restart_messages_job.rb
+++ b/app/jobs/restart_messages_job.rb
@@ -5,7 +5,7 @@ class RestartMessagesJob < ApplicationJob
 
   def perform(user)
     if user.update(contactable: true)
-      message = Message.create(user: user, body: "Welcome back to Tiny Happy People! Text 'stop' to unsubscribe at any time.")
+      message = Message.create(user: user, body: "Welcome back to Tiny Happy People! Text 'END' to unsubscribe at any time.")
 
       Twilio::Client.new.send_message(message)
     end

--- a/db/migrate/20250401092239_add_end_auto_response.rb
+++ b/db/migrate/20250401092239_add_end_auto_response.rb
@@ -1,0 +1,5 @@
+class AddEndAutoResponse < ActiveRecord::Migration[8.0]
+  def change
+    AutoResponse.find_by(trigger_phrase: "end").update(response: "Hi there! Thank you so much for being part of the Tiny Happy People text messaging programme. Before we stop sending you texts, could you let us know why you've decided to stop/pause? You can just text back the number that matches your reason, or feel free to reply with your own thoughts. 1. My family and I don’t have time to engage with the texts right now. 2. The texts don’t feel relevant to my family’s needs. 3. I get too many texts and it feels overwhelming. 4. Other (please share your reason). Thanks again! We really appreciate your feedback.")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_04_01_084554) do
+ActiveRecord::Schema[8.0].define(version: 2025_04_01_092239) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 

--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -41,7 +41,7 @@ namespace :scheduler do
     (next unless Date.today.wday == ENV.fetch("WEEKLY_NUDGE_DAY").to_i) if ENV.fetch("SET_WEEKLY") == "true"
 
     User.contactable.not_nudged.not_clicked_last_x_messages(3).each do |user|
-      message = Message.create(user:, body: "You've not interacted with any videos lately. You can text 'PAUSE' for a break or 'STOP' to stop them entirely.")
+      message = Message.create(user:, body: "You've not interacted with any videos lately. You can text 'PAUSE' for a break or 'END' to stop them entirely.")
       SendCustomMessageJob.perform_later(message)
       user.update(nudged_at: Time.now)
     end

--- a/test/jobs/restart_messages_job_test.rb
+++ b/test/jobs/restart_messages_job_test.rb
@@ -7,7 +7,7 @@ class RestartMessagesJobTest < ActiveSupport::TestCase
   test "#perform updates user and sends message" do
     user = create(:user, contactable: false)
 
-    stub_successful_twilio_call("Welcome back to Tiny Happy People! Text 'stop' to unsubscribe at any time.", user)
+    stub_successful_twilio_call("Welcome back to Tiny Happy People! Text 'END' to unsubscribe at any time.", user)
 
     RestartMessagesJob.new.perform(user)
 

--- a/test/lib/scheduler_test.rb
+++ b/test/lib/scheduler_test.rb
@@ -113,7 +113,7 @@ class SchedulerTest < ActiveSupport::TestCase
       Rake::Task["scheduler:check_for_disengaged_users"].execute
     end
 
-    assert_equal 1, Message.where(body: "You've not interacted with any videos lately. You can text 'PAUSE' for a break or 'STOP' to stop them entirely.").count
+    assert_equal 1, Message.where(body: "You've not interacted with any videos lately. You can text 'PAUSE' for a break or 'END' to stop them entirely.").count
   end
 
   test "get_user_feedback" do


### PR DESCRIPTION
Change stop word to "END" so that we can send follow up text to users (Twilio automatically blocks 'STOP').