### PR TITLE
Validate child birthday on user creation

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,7 +9,7 @@ class User < ApplicationRecord
   validates :phone_number, :first_name, :last_name, :child_birthday, :terms_agreed_at, :postcode, presence: true
   validates_uniqueness_of :phone_number
   validates_plausible_phone :phone_number
-  validates :child_birthday, inclusion: {in: ((Date.today - 27.months)...(Date.today - 3.months))}
+  validates :child_birthday, inclusion: {in: ((Date.today - 27.months)...(Date.today - 3.months))}, on: :create
 
   phony_normalize :phone_number, default_country_code: "UK"
 

--- a/test/jobs/send_message_job_test.rb
+++ b/test/jobs/send_message_job_test.rb
@@ -74,7 +74,7 @@ class SendMessageJobTest < ActiveSupport::TestCase
   test "#perform does not send message if user fails to update" do
     content = create(:content, body: "here is a link: {{link}}")
     create(:content, group: content.group, body: "here is a link: {{link}}")
-    user = build(:user, last_content_id: content.id, child_birthday: 3.years.ago)
+    user = build(:user, last_content_id: content.id, phone_number: "234")
     user.save(validate: false)
 
     Message.any_instance.stubs(:generate_token).returns("123")

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -22,17 +22,22 @@ class UserTest < ActiveSupport::TestCase
   test("last_name required") { assert_present(:last_name) }
   test("child_birthday required") { assert_present(:child_birthday) }
 
-  test "child_birthday is within the last 27 months" do
-    @subject.child_birthday = Time.now - 28.months
-    assert_not @subject.valid?
-
-    @subject.child_birthday = Time.now + 1.month
-    assert_not @subject.valid?
+  test "child_birthday is within the last 27 months on create" do
+    assert_raises ActiveRecord::RecordInvalid do
+      create(:user, child_birthday: Time.now - 28.months)
+    end
   end
 
-  test "child_birthday is not less than 3 months" do
-    @subject.child_birthday = Time.now - 2.months
-    assert_not @subject.valid?
+  test "child_birthday is not less than 3 months on create" do
+    assert_raises ActiveRecord::RecordInvalid do
+      create(:user, child_birthday: Time.now - 2.months)
+    end
+  end
+
+  test "child_birthday is not validated on update" do
+    @subject.update(child_birthday: Time.now + 28.months)
+
+    assert @subject.valid?
   end
 
   test "contactable scope" do

--- a/test/services/response_matcher_service_test.rb
+++ b/test/services/response_matcher_service_test.rb
@@ -133,7 +133,7 @@ class ResponseMatcherServiceTest < ActiveSupport::TestCase
     create(:auto_response, trigger_phrase: "restart", response: "You're all set to start receiving messages again!", update_user: "{\"contactable\": false}")
     user = create(:user)
     message = build(:message, body: "restart", status: "received", user:)
-    user.child_birthday = 1.month.ago
+    user.phone_number = "1112"
     user.save(validate: false)
     refute user.valid?
 


### PR DESCRIPTION
This is to ensure that if a child's age goes out of the valid range, they will still receive messages. e.g. the content might last longer than the valid range of the child's age.