### PR TITLE
Clean up message logic

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -12,7 +12,13 @@ class MessagesController < ApplicationController
       message_sid = params["MessageSid"]
       status = params["MessageStatus"]
 
-      Message.find_by(message_sid:)&.update(status:, sent_at: Time.now)
+      message = Message.find_by(message_sid:)
+
+      return if message.nil? || message.status == "delivered"
+
+      message.update(status:)
+
+      message.update(sent_at: Time.now) if message.status == "delivered"
     end
   end
 
@@ -24,11 +30,14 @@ class MessagesController < ApplicationController
   end
 
   def next
-    @message = Message.find_by(token: params[:token])
+    message = Message.find_by(token: params[:token])
 
-    @message.update(clicked_at: Time.now)
-
-    redirect_to @message.link, allow_other_host: true
+    if message.present?
+      message.update(clicked_at: Time.now)
+      redirect_to message.link, allow_other_host: true
+    else
+      redirect_to "https://www.bbc.co.uk/tiny-happy-people", allow_other_host: true
+    end
   end
 
   def new

--- a/app/jobs/send_message_job.rb
+++ b/app/jobs/send_message_job.rb
@@ -4,11 +4,11 @@ class SendMessageJob < ApplicationJob
   queue_as :default
 
   def perform(user)
-    content = user.next_content
-
-    return unless content.present?
     # If BulkMessage fails and reruns this job, don't send them the next message
     return if user.had_content_this_week?
+
+    content = user.next_content
+    return unless content.present?
 
     message = Message.build do |m|
       m.token = m.send(:generate_token)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -81,7 +81,7 @@ class User < ApplicationRecord
   end
 
   def had_content_this_week?
-    messages.where("created_at > ?", 6.days.ago).where.not(content: nil).exists?
+    messages.any? { |m| m.created_at > 6.days.ago && m.content_id.present? }
   end
 
   def update_local_authority
@@ -99,7 +99,7 @@ class User < ApplicationRecord
   end
 
   def not_seen_content?(content)
-    messages.where(content_id: content.id).none?
+    messages.none? { |m| m.content_id == content.id }
   end
 
   def find_next_unseen_content


### PR DESCRIPTION
- Makes logic for finding next message more efficient, using fewer queries.
- Ensures message status 'delivered' can't be overwritten
- Makes more robust if somehow system can't find message link to redirect to