### PR TITLE
Move messages status update to a job

### DIFF
--- a/app/jobs/update_message_status_job.rb
+++ b/app/jobs/update_message_status_job.rb
@@ -1,0 +1,16 @@
+class UpdateMessageStatusJob < ApplicationJob
+  queue_as :default
+
+  def perform(params)
+    message_sid = params[:MessageSid]
+    status = params[:MessageStatus]
+
+    message = Message.find_by(message_sid:)
+
+    return if message.nil? || message.status == "delivered"
+
+    if message.update(status:)
+      message.update(sent_at: Time.zone.now) if message.status == "delivered"
+    end
+  end
+end

--- a/test/jobs/update_message_status_job.rb
+++ b/test/jobs/update_message_status_job.rb
@@ -1,0 +1,30 @@
+require "test_helper"
+
+class UpdateMessageStatusJobTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
+  test "#perform should update message status" do
+    message = create(:message, message_sid: "123")
+
+    UpdateMessageStatusJob.new.perform({MessageSid: message.message_sid, MessageStatus: "delivered"})
+
+    message.reload
+    assert_equal "delivered", message.status
+    assert_not_nil message.sent_at
+  end
+
+  test "#perform should not override delivered status" do
+    message = create(:message, status: "delivered", message_sid: "123")
+
+    UpdateMessageStatusJob.new.perform({MessageSid: message.message_sid, MessageStatus: "delivered"})
+
+    message.reload
+    assert_equal "delivered", message.status
+  end
+
+  test "#perform should not crash if it can't find the message" do
+    assert_nothing_raised do
+      UpdateMessageStatusJob.new.perform({MessageSid: "123", MessageStatus: "delivered"})
+    end
+  end
+end


### PR DESCRIPTION
If we're getting lots of updates from Twilio, we don't want to block the service with these requests.