### PR TITLE
Clear finished jobs every 2 months

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -30,5 +30,8 @@ module AfsTinyHappyPeople
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+
+    # Clear out old finished jobs from the SolidQueue database.
+    config.solid_queue.clear_finished_jobs_after = 2.months
   end
 end

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -33,3 +33,7 @@ production:
   update_las_specific:
     command: "LaSpecificDashboard.refresh"
     schedule: 0 * * * *
+  clear_finished_jobs:
+    command: "SolidQueue::Job.clear_finished_in_batches"
+    schedule: 0 2 * * *
+


### PR DESCRIPTION
This frees up database space, but keeps jobs around for audit/debugging purposes.