### PR TITLE
Restrict access to admin sign-in to IP address

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,0 +1,11 @@
+class SessionsController < Devise::Passwordless::SessionsController
+  prepend_before_action :check_ip, only: [:new, :create]
+
+  private
+
+  def check_ip
+    if Rails.env.production? && request.ip != ENV.fetch("ADMIN_IP_WHITELIST")
+      redirect_to root_path, alert: "Access denied."
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,14 +15,9 @@ Rails.application.routes.draw do
     end
 
     resources :admins, except: %i[show destroy]
-
-    resources :content_adjustments, only: %i[index show edit update] do
-      get "automated", on: :collection
-      get "incomplete", on: :collection
-    end
   end
 
-  devise_for :admins, skip: :registrations, controllers: {sessions: "devise/passwordless/sessions"}
+  devise_for :admins, skip: :registrations, controllers: {sessions: "sessions"}
   get "up" => "rails/health#show", :as => :rails_health_check
 
   # Defines the root path route ("/")


### PR DESCRIPTION
Following PEN test, restrict access to admin sign-in to a specific IP address.