### PR TITLE
Fix skip to main content link for Safari

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,7 +18,7 @@
   <body class="bg-slate-50">
     <a href="#main" data-turbo="false" class="absolute -top-20 left-0 z-[100] focus:top-0 focus:left-0 p-4 text-white bg-bbc-dark-blue text-lg">Skip to main content</a>
     <%= render "layouts/navbar" %>
-    <main class="w-full" role="main" id="main">
+    <main class="w-full" role="main" id="main" tabindex="-1">
       <% if current_admin && @hide_sidebar.blank? %>
         <div class="grid grid-cols-4 h-svh">
           <%= render "layouts/sidebar" %>


### PR DESCRIPTION
Works on other browsers but Safari seems to have more issues.

Trying this for now!