### PR TITLE
Make code improvements based on Thoughtbot audit

### DIFF
--- a/app/controllers/admin/contents_controller.rb
+++ b/app/controllers/admin/contents_controller.rb
@@ -38,7 +38,7 @@ class Admin::ContentsController < ApplicationController
     if @content.update(archived_at: Time.zone.now)
       redirect_to admin_group_path(@content.group), notice: "Content archived"
     else
-      render admin_group_path(@content.group), status: :unprocessable_content
+      redirect_to admin_group_path(@content.group), status: :unprocessable_content
     end
   end
 

--- a/app/models/content.rb
+++ b/app/models/content.rb
@@ -8,9 +8,11 @@ class Content < ApplicationRecord
   has_many :messages, dependent: :restrict_with_exception
 
   validates :body, :age_in_months, presence: true
-  validate :valid_link?, if: -> { link.present? }
+  validates :link, format: {with: URI::DEFAULT_PARSER.make_regexp(%w[http https])}, allow_blank: true
 
   scope :active, -> { where(archived_at: nil) }
+
+  after_create :check_link_status
 
   def archived?
     archived_at.present?
@@ -18,14 +20,7 @@ class Content < ApplicationRecord
 
   private
 
-  def valid_link?
-    uri = URI.parse(link)
-    response = Net::HTTP.get_response(uri)
-
-    if response.code != "200"
-      errors.add(:link, "is not valid or does not return a 200 status code. Please check the link and try again.")
-    end
-  rescue
-    errors.add(:link, "is not a valid URL. Please check the link and try again.")
+  def check_link_status
+    CheckBbcLinksJob.perform_later if link.present?
   end
 end

--- a/app/services/twilio/client.rb
+++ b/app/services/twilio/client.rb
@@ -20,6 +20,10 @@ module Twilio
 
       message.update(status: sms.status, message_sid: sms.sid)
     rescue Twilio::REST::RestError
+      Appsignal.report_error(StandardError.new("Twilio message failed")) do
+        Appsignal.add_tags(message_id: message.id, user_id: message.user.id)
+      end
+
       message.update(status: "failed")
     end
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,6 +4,10 @@ en:
       messages:
         blank: "can't be blank"
       models:
+        content: 
+          attributes:
+            link: 
+              invalid: "is not a valid URL. Please check the link and try again."
         user:
           attributes:
             child_birthday:

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -46,7 +46,7 @@ production:
     schedule: 0 2 * * *
   check_bbc_links:
     class: CheckBbcLinksJob
-    schedule: 0 1 * * 3
+    schedule: 0 1 * * *
   send_survey_reminder:
     class: SendBulkMessageJob
     args: [ survey_reminder ]

--- a/db/migrate/20250704130210_add_up_option_down_option_to_content_adjustment.rb
+++ b/db/migrate/20250704130210_add_up_option_down_option_to_content_adjustment.rb
@@ -1,4 +1,7 @@
 class AddUpOptionDownOptionToContentAdjustment < ActiveRecord::Migration[8.0]
+  class ContentAdjustment < ApplicationRecord
+  end
+
   def change
     add_column :content_adjustments, :number_up_options, :integer
     add_column :content_adjustments, :number_down_options, :integer

--- a/db/migrate/20260505131919_add_index_foreign_key_on_messages_user_id.rb
+++ b/db/migrate/20260505131919_add_index_foreign_key_on_messages_user_id.rb
@@ -1,0 +1,6 @@
+class AddIndexForeignKeyOnMessagesUserId < ActiveRecord::Migration[8.1]
+  def change
+    add_index :messages, :user_id
+    add_foreign_key :messages, :users, column: :user_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_27_085835) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_05_131919) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -219,6 +219,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_27_085835) do
     t.bigint "user_id"
     t.index ["content_id"], name: "index_messages_on_content_id"
     t.index ["token"], name: "index_messages_on_token", unique: true
+    t.index ["user_id"], name: "index_messages_on_user_id"
   end
 
   create_table "questions", force: :cascade do |t|
@@ -435,6 +436,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_27_085835) do
   add_foreign_key "answers", "users"
   add_foreign_key "interests", "users"
   add_foreign_key "messages", "contents"
+  add_foreign_key "messages", "users"
   add_foreign_key "questions", "survey_sections"
   add_foreign_key "solid_queue_blocked_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
   add_foreign_key "solid_queue_claimed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade

--- a/test/models/content_test.rb
+++ b/test/models/content_test.rb
@@ -18,11 +18,14 @@ class ContentTest < ActiveSupport::TestCase
     content = Content.new(link: "invalid_url")
     content.save
     assert_error(:link, "is not a valid URL. Please check the link and try again.", subject: content)
+  end
 
-    stub_request(:any, /notrealdomain.com/).to_return(status: 404)
-    content = Content.new(link: "https://notrealdomain.com")
-    content.save
-    assert_error(:link, "is not valid or does not return a 200 status code. Please check the link and try again.", subject: content)
+  test "checkLinkStatus is called after create" do
+    content = build(:content, link: "https://www.bbc.co.uk/some-link")
+
+    CheckBbcLinksJob.expects(:perform_later)
+
+    content.save!
   end
 
   test "destroy does not delete associated messages" do

--- a/test/system/messages_test.rb
+++ b/test/system/messages_test.rb
@@ -26,8 +26,8 @@ class MessagesTest < ApplicationSystemTestCase
   test "can track whether a user has clicked on the link" do
     sign_in
 
-    content = create(:content, link: root_path)
-    message = create(:message, user: @user, content: content, link: root_path)
+    content = create(:content, link: root_url)
+    message = create(:message, user: @user, content: content, link: root_url)
 
     visit track_link_path(message.token)
 


### PR DESCRIPTION
- Validate links asynchronously by removing `Content#valid_link?` validation and relying on `CheckBbcLinksJob` to check link status after content creation.
- Add error reporting to Appsignal in `Twilio::Client#send_message` rescue block
- Fix `Admin::ContentsController#archive` failure path by changing `render` to `redirect_to` with appropriate status code.
- Add an inline `ContentAdjustment` class to the migration `20250704130210_add_up_option_down_option_to_content_adjustment.rb` to prevent migration failures on fresh setups.
- Add an index and foreign key on `messages.user_id` to improve query performance and data integrity.