### PR TITLE
Update CheckBbcLinksJob

### DIFF
--- a/app/jobs/check_bbc_links_job.rb
+++ b/app/jobs/check_bbc_links_job.rb
@@ -6,20 +6,26 @@ class CheckBbcLinksJob < ApplicationJob
 
   def perform
     Appsignal::CheckIn.cron("check_bbc_links_job") do
-      Content.pluck(:link).each do |link|
-        uri = URI.parse(link)
-
-        begin
-          response = Net::HTTP.get_response(uri)
-
-          if response.code != "200"
-            error = StandardError.new("Link #{link} returned status code #{response.code}")
-            Appsignal.report_error(error)
-          end
-        rescue => e
-          Appsignal.report_error(e)
-        end
+      Content.active.find_each do |content|
+        next if content.link.blank?
+        check(content)
       end
     end
   end
+
+  def check(content)
+    uri = URI.parse(content.link)
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = uri.scheme == "https"
+    http.open_timeout = 5
+    http.read_timeout = 5
+    response = http.request(Net::HTTP::Get.new(uri))
+    return if response.code == "200"
+    Appsignal.report_error(StandardError.new("Link #{content.link} returned #{response.code}"))
+  rescue *HTTP_ERRORS => e
+    Appsignal.report_error(e)
+  end
+
+  HTTP_ERRORS = [Timeout::Error, Errno::ECONNRESET, Net::HTTPBadResponse,
+    SocketError, Errno::ECONNREFUSED, OpenSSL::SSL::SSLError, URI::InvalidURIError].freeze
 end

--- a/test/jobs/check_bbc_links_job_test.rb
+++ b/test/jobs/check_bbc_links_job_test.rb
@@ -5,19 +5,19 @@ class CheckBbcLinksJobTest < ActiveSupport::TestCase
   include Rails.application.routes.url_helpers
 
   test "#perform checks BBC links and logs errors" do
-    stub_request(:get, /www.bbc.co.uk\/some-valid-link/).to_return(status: 200)
-    stub_request(:get, /www.bbc.co.uk\/some-invalid-link/).to_return(status: 200)
-
     create(:content, link: "https://www.bbc.co.uk/some-valid-link")
     create(:content, link: "https://www.bbc.co.uk/some-invalid-link")
+    create(:content, link: "https://www.example.com/other-link", archived_at: 1.day.ago)
 
     stub_request(:get, "https://www.bbc.co.uk/some-valid-link")
       .to_return(status: 200, body: "OK")
     stub_request(:get, "https://www.bbc.co.uk/some-invalid-link")
       .to_return(status: 404, body: "Not Found")
+    stub_request(:get, "https://www.example.com/other-link")
+      .to_return(status: 404, body: "Not Found")
 
     Appsignal.expects(:report_error).once.with do |error|
-      error.message == "Link https://www.bbc.co.uk/some-invalid-link returned status code 404"
+      error.message == "Link https://www.bbc.co.uk/some-invalid-link returned 404"
     end
 
     CheckBbcLinksJob.new.perform


### PR DESCRIPTION
- Only checks active content links now, not archived ones.
- Sets a timeout for the HTTP request and reports errors to Appsignal with a clearer message.