### PR TITLE
Anonymise user messages too

### DIFF
--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,7 +1,7 @@
 class Message < ApplicationRecord
   belongs_to :user
   belongs_to :content, optional: true
-  validates :body, presence: true
+  validates :body, presence: true, unless: :user_anonymised?
 
   scope :with_content, -> { where.not(content: nil) }
   scope :clicked, -> { with_content.where.not(clicked_at: nil) }
@@ -42,5 +42,9 @@ class Message < ApplicationRecord
 
   def generate_reply
     ResponseMatcherService.new(self).match_response
+  end
+
+  def user_anonymised?
+    user.anonymised?
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -169,20 +169,27 @@ class User < ApplicationRecord
   def anonymise!
     return if anonymised?
 
-    update!(
-      anonymised_at: Time.zone.now,
-      first_name: nil,
-      child_name: nil,
-      phone_number: "anonymised",
-      postcode: "anonymised",
-    )
-  end
+    ActiveRecord::Base.transaction do
+      update!(
+        anonymised_at: Time.zone.now,
+        first_name: nil,
+        child_name: nil,
+        phone_number: "anonymised",
+      )
 
-  private
+      messages.where.not(status: "received").update_all(body: nil)
+    end
+  rescue ActiveRecord::RecordInvalid => e
+    Appsignal.report_error("User and associated messages failed to anonymise: #{e.message}") do
+      Appsignal.add_tags(user_info: attributes)
+    end
+  end
 
   def anonymised?
     anonymised_at.present?
   end
+
+  private
 
   def assign_group_by_language
     self.group = Group.find_by(language: language)

--- a/test/jobs/anonymise_users_job_test.rb
+++ b/test/jobs/anonymise_users_job_test.rb
@@ -13,7 +13,6 @@ class AnonymiseUsersJobTest < ActiveSupport::TestCase
     assert old_user.first_name.nil?
     assert old_user.child_name.nil?
     assert_equal "anonymised", old_user.phone_number
-    assert_equal "anonymised", old_user.postcode
 
     assert recent_user.reload.anonymised_at.nil?
   end

--- a/test/models/message_test.rb
+++ b/test/models/message_test.rb
@@ -9,9 +9,15 @@ class MessageTest < ActiveSupport::TestCase
     assert @message.valid?
   end
 
-  test "content should be present" do
+  test "body should be present" do
     @message.body = ""
     assert_not @message.valid?
+  end
+
+  test "body can be blank if user is anonymised" do
+    user = create(:user, anonymised_at: Time.current)
+    message = build(:message, user:, body: "")
+    assert message.valid?
   end
 
   test "#generate_reply only runs if message status is received" do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -527,6 +527,8 @@ class UserTest < ActiveSupport::TestCase
 
   test "anonymise! method anonymises user data" do
     user = create(:user, first_name: "Jane", child_name: "John", phone_number: "07123456789", postcode: "SW1A 1AA")
+    anonymised_message = create(:message, user:, status: "sent", body: "This is a message body that should be anonymised")
+    not_anonymised_message = create(:message, user:, status: "received", body: "This is a message body that should not be anonymised")
 
     user.anonymise!
 
@@ -534,6 +536,20 @@ class UserTest < ActiveSupport::TestCase
     assert_nil user.first_name
     assert_nil user.child_name
     assert_equal user.phone_number, "anonymised"
-    assert_equal user.postcode, "anonymised"
+    assert_nil anonymised_message.reload.body
+    assert_equal "This is a message body that should not be anonymised", not_anonymised_message.reload.body
+  end
+
+  test "if anonymise! fails to update a message, it reports the error to Appsignal" do
+    user = create(:user)
+    create(:message, user:, status: "sent", body: "This is a message body that should be anonymised")
+
+    user.stubs(:update!).raises(ActiveRecord::RecordInvalid.new(user))
+
+    Appsignal.expects(:report_error).once.with do |error|
+      error == "User and associated messages failed to anonymise: Validation failed: "
+    end
+
+    user.anonymise!
   end
 end


### PR DESCRIPTION
- Postcode is no longer anonymised
- Message bodies are anonymised for all messages except those with status "received", since they may contain user's first name and child's name