### PR TITLE
Put response matcher in job

### DIFF
--- a/app/jobs/response_matcher_job.rb
+++ b/app/jobs/response_matcher_job.rb
@@ -1,0 +1,7 @@
+class ResponseMatcherJob < ApplicationJob
+  queue_as :default
+
+  def perform(message)
+    ResponseMatcherService.new(message).match_response
+  end
+end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -41,7 +41,7 @@ class Message < ApplicationRecord
   end
 
   def generate_reply
-    ResponseMatcherService.new(self).match_response
+    ResponseMatcherJob.perform_later(self)
   end
 
   def user_anonymised?

--- a/test/controllers/messages_controller_test.rb
+++ b/test/controllers/messages_controller_test.rb
@@ -2,6 +2,7 @@ require "test_helper"
 
 class MessagesControllerTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
+  include ActiveJob::TestHelper
 
   setup do
     @user = create(:user)
@@ -99,6 +100,7 @@ class MessagesControllerTest < ActionDispatch::IntegrationTest
 
     post messages_incoming_url, params: {From: @user.phone_number, Body: "Hi", MessageSid: "new_sid"}
     assert_response :success
+    perform_enqueued_jobs
 
     assert_equal "The team's working hours are 9am - 6pm, Monday to Friday. We'll get back to you as soon as we can.", @user.messages.last.body
   end
@@ -109,6 +111,7 @@ class MessagesControllerTest < ActionDispatch::IntegrationTest
 
     post messages_incoming_url, params: {From: @user.phone_number, Body: "STOP", MessageSid: "new_sid"}
     assert_response :success
+    perform_enqueued_jobs
     @user.reload
     assert_equal @user.contactable, false
   end

--- a/test/jobs/response_matcher_job_test.rb
+++ b/test/jobs/response_matcher_job_test.rb
@@ -1,0 +1,22 @@
+require "test_helper"
+
+class ResponseMatcherJobTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
+  test "#perform delegates to ResponseMatcherService" do
+    message = create(:message)
+    service = mock
+    service.expects(:match_response).once
+    ResponseMatcherService.expects(:new).with(message).returns(service)
+
+    ResponseMatcherJob.new.perform(message)
+  end
+
+  test ".perform_later enqueues the job on the default queue" do
+    message = create(:message)
+
+    assert_enqueued_with(job: ResponseMatcherJob, args: [message], queue: "default") do
+      ResponseMatcherJob.perform_later(message)
+    end
+  end
+end

--- a/test/models/message_test.rb
+++ b/test/models/message_test.rb
@@ -1,6 +1,8 @@
 require "test_helper"
 
 class MessageTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
   def setup
     @message = build(:message)
   end
@@ -22,30 +24,30 @@ class MessageTest < ActiveSupport::TestCase
 
   test "#generate_reply only runs if message status is received" do
     user = create(:user)
-    message = create(:message, status: "delivered", user:, body: "stop")
-
-    assert message.user.contactable
+    assert_enqueued_jobs 0 do
+      create(:message, status: "delivered", user:, body: "stop")
+    end
   end
 
   test "#generate_reply when user texts stop" do
     create(:auto_response, trigger_phrase: "stop", update_user: "{\"contactable\": false}")
-    message = create(:message, body: "stop", status: "received")
-
-    refute message.user.contactable
+    assert_enqueued_jobs 1, only: ResponseMatcherJob do
+      create(:message, body: "stop", status: "received")
+    end
   end
 
   test "#generate_reply when user texts start" do
     create(:auto_response, trigger_phrase: "start", update_user: "{\"contactable\": true}")
-    message = create(:message, body: "start", status: "received")
-
-    assert message.user.contactable
+    assert_enqueued_jobs 1, only: ResponseMatcherJob do
+      create(:message, body: "start", status: "received")
+    end
   end
 
   test "#generate_reply when user texts anything else" do
     message = build(:message, body: "blah", status: "received")
-
-    ResponseMatcherService.expects(:new).with(message).returns(stub(match_response: true))
-    message.save
+    assert_enqueued_jobs 1, only: ResponseMatcherJob do
+      message.save
+    end
   end
 
   test "#admin_status returns the status of the message" do


### PR DESCRIPTION
- Auto-replies to incoming SMS were running synchronously in the create path
- This makes it asynchronous by moving the logic to a job, which is enqueued in the create path