### PR TITLE
Remove unique index on `survey_sends` table

### DIFF
--- a/app/jobs/send_survey_reminder_job.rb
+++ b/app/jobs/send_survey_reminder_job.rb
@@ -4,6 +4,8 @@ class SendSurveyReminderJob < ApplicationJob
   queue_as :background
 
   def perform(user, survey)
+    return if SurveySend.where(user: user, survey: survey, sent_at: Time.zone.now.beginning_of_day..).exists?
+
     survey_url = edit_survey_url(survey, token: user.generate_token_for(:survey_token))
 
     message = Message.build do |m|

--- a/db/migrate/20260507120000_remove_unique_index_from_survey_sends.rb
+++ b/db/migrate/20260507120000_remove_unique_index_from_survey_sends.rb
@@ -1,0 +1,6 @@
+class RemoveUniqueIndexFromSurveySends < ActiveRecord::Migration[8.1]
+  def change
+    remove_index :survey_sends, column: [:user_id, :survey_id], unique: true
+    add_index :survey_sends, [:user_id, :survey_id]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_05_131919) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_07_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -384,7 +384,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_05_131919) do
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
     t.index ["survey_id"], name: "index_survey_sends_on_survey_id"
-    t.index ["user_id", "survey_id"], name: "index_survey_sends_on_user_id_and_survey_id", unique: true
+    t.index ["user_id", "survey_id"], name: "index_survey_sends_on_user_id_and_survey_id"
     t.index ["user_id"], name: "index_survey_sends_on_user_id"
   end
 

--- a/test/jobs/send_survey_reminder_job_test.rb
+++ b/test/jobs/send_survey_reminder_job_test.rb
@@ -53,4 +53,29 @@ class SendSurveyReminderJobTest < ActiveSupport::TestCase
 
     assert_equal 0, SurveySend.count
   end
+
+  test "#perform does not send another reminder on the same day" do
+    user = create(:user)
+    survey = create(:survey)
+    SurveySend.create!(user: user, survey: survey, sent_at: Time.current.beginning_of_day + 1.hour)
+
+    assert_no_enqueued_jobs only: SendCustomMessageJob do
+      SendSurveyReminderJob.new.perform(user, survey)
+    end
+
+    assert_equal 0, Message.count
+    assert_equal 1, SurveySend.count
+  end
+
+  test "#perform sends a reminder if the previous SurveySend was on a previous day" do
+    user = create(:user)
+    survey = create(:survey)
+    SurveySend.create!(user: user, survey: survey, sent_at: 1.day.ago)
+
+    assert_enqueued_jobs 1, only: SendCustomMessageJob do
+      SendSurveyReminderJob.new.perform(user, survey)
+    end
+
+    assert_equal 2, SurveySend.where(user: user, survey: survey).count
+  end
 end


### PR DESCRIPTION
-  This is necessary to enable sending multiple reminders for the same survey send, which is a common use case when users do not respond to the initial survey invitation.