### PR TITLE
Anonymise visitor_token in Ahoy tracking

### DIFF
--- a/app/controllers/surveys_controller.rb
+++ b/app/controllers/surveys_controller.rb
@@ -3,6 +3,7 @@ class SurveysController < ApplicationController
   before_action :set_survey, only: [:edit, :update]
   before_action :set_user, only: [:edit, :update, :thank_you]
   before_action :set_questions, :set_answers, only: [:edit]
+  after_action :track_action, only: [:edit, :thank_you]
 
   def edit
     @hide_sidebar = true
@@ -58,5 +59,9 @@ class SurveysController < ApplicationController
         answers_attributes: [:id, :question_id, :user_id, :response, {response: []}],
       ],
     )
+  end
+
+  def track_action
+    ahoy.track request.path_parameters[:action], request.path_parameters
   end
 end

--- a/app/views/layouts/_cookie_banner.html.erb
+++ b/app/views/layouts/_cookie_banner.html.erb
@@ -1,4 +1,4 @@
-<script nonce="<%= content_security_policy_nonce %>">
+<script type="module" nonce="<%= content_security_policy_nonce %>">
   window.dataLayer = window.dataLayer || [];
   function gtag() { dataLayer.push(arguments); }
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,7 +15,7 @@
     <%= content_for :scripts %>
 
     <% unless Rails.env.test? %>
-      <script src="https://cc.cdn.civiccomputing.com/9/cookieControl-9.x.min.js" data-turbo-track="reload" nonce="<%= content_security_policy_nonce %>"></script>
+      <script defer src="https://cc.cdn.civiccomputing.com/9/cookieControl-9.x.min.js" data-turbo-track="reload" nonce="<%= content_security_policy_nonce %>"></script>
     <% end %>
 
     <script nonce="<%= content_security_policy_nonce %>">

--- a/config/initializers/ahoy.rb
+++ b/config/initializers/ahoy.rb
@@ -11,3 +11,13 @@ Ahoy.geocode = false
 
 # Don't collect cookies
 Ahoy.cookies = :none
+
+Ahoy.user_method = :current_admin
+
+module AhoyRandomVisitorToken
+  def visitor_anonymity_set
+    @visitor_anonymity_set ||= SecureRandom.hex(16)
+  end
+end
+
+Ahoy::Tracker.prepend(AhoyRandomVisitorToken)

--- a/db/migrate/20260512124931_fix_ahoy_tracking_agent.rb
+++ b/db/migrate/20260512124931_fix_ahoy_tracking_agent.rb
@@ -1,0 +1,13 @@
+class FixAhoyTrackingAgent < ActiveRecord::Migration[8.1]
+  def change
+    remove_column :ahoy_visits, :user_agent, :string
+
+    remove_column :ahoy_events, :user_id, :uuid
+    remove_column :ahoy_visits, :user_id, :uuid
+
+    add_column :ahoy_events, :user_id, :bigint
+    add_index :ahoy_events, :user_id
+    add_column :ahoy_visits, :user_id, :bigint
+    add_index :ahoy_visits, :user_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_07_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_12_124931) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -69,7 +69,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_07_120000) do
     t.string "name"
     t.jsonb "properties"
     t.datetime "time"
-    t.uuid "user_id"
+    t.bigint "user_id"
     t.bigint "visit_id"
     t.index ["name", "time"], name: "index_ahoy_events_on_name_and_time"
     t.index ["properties"], name: "index_ahoy_events_on_properties", opclass: :jsonb_path_ops, using: :gin
@@ -85,8 +85,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_07_120000) do
     t.text "referrer"
     t.string "referring_domain"
     t.datetime "started_at"
-    t.text "user_agent"
-    t.uuid "user_id"
+    t.bigint "user_id"
     t.string "visit_token"
     t.string "visitor_token"
     t.index ["user_id"], name: "index_ahoy_visits_on_user_id"


### PR DESCRIPTION
To comply with GDPR regulations.

This change ensures that the visitor_token is not stored in a way that can be used to identify individual users, while still allowing us to track visits and actions for analytics purposes.

Also track surveys