### PR TITLE
Only generate message tokens for messages with links

### DIFF
--- a/app/controllers/admin/survey_sections_controller.rb
+++ b/app/controllers/admin/survey_sections_controller.rb
@@ -16,7 +16,7 @@ class Admin::SurveySectionsController < ApplicationController
 
   def create
     @survey_section = @survey.survey_sections.new(survey_section_params)
-    if @survey_section.save!
+    if @survey_section.save
       redirect_to admin_survey_path(@survey), notice: "Survey was successfully created."
     else
       render :new, status: :unprocessable_content

--- a/app/jobs/send_bilingual_message_job.rb
+++ b/app/jobs/send_bilingual_message_job.rb
@@ -6,7 +6,7 @@ class SendBilingualMessageJob < ApplicationJob
 
   def perform(user)
     message = Message.build do |m|
-      m.token = m.send(:generate_token)
+      m.token = SecureRandom.alphanumeric(6)
       m.user = user
       m.body = substitute_variables(
         I18n.t(".messages.bilingual_text", locale: user.language || I18n.default_locale),

--- a/app/jobs/send_feedback_message_job.rb
+++ b/app/jobs/send_feedback_message_job.rb
@@ -3,7 +3,6 @@ class SendFeedbackMessageJob < ApplicationJob
 
   def perform(user)
     message = Message.build do |m|
-      m.token = m.send(:generate_token)
       m.user = user
       m.body = I18n.t(".messages.feedback", locale: user.language || I18n.default_locale)
     end

--- a/app/jobs/send_message_job.rb
+++ b/app/jobs/send_message_job.rb
@@ -13,7 +13,7 @@ class SendMessageJob < ApplicationJob
     return if content.blank?
 
     message = Message.build do |m|
-      m.token = m.send(:generate_token)
+      m.token = SecureRandom.alphanumeric(6)
       m.link = content.link
       m.user = user
       m.body = substitute_variables(content.body, user, token: m.token)

--- a/app/jobs/send_survey_job.rb
+++ b/app/jobs/send_survey_job.rb
@@ -9,7 +9,6 @@ class SendSurveyJob < ApplicationJob
     survey_url = edit_survey_url(survey, token: user.generate_token_for(:survey_token))
 
     message = Message.build do |m|
-      m.token = m.send(:generate_token)
       m.user = user
       m.body = I18n.t(".messages.survey", locale: user.language || I18n.default_locale).gsub("{{survey_url}}", survey_url)
     end

--- a/app/jobs/send_survey_reminder_job.rb
+++ b/app/jobs/send_survey_reminder_job.rb
@@ -9,7 +9,6 @@ class SendSurveyReminderJob < ApplicationJob
     survey_url = edit_survey_url(survey, token: user.generate_token_for(:survey_token))
 
     message = Message.build do |m|
-      m.token = m.send(:generate_token)
       m.user = user
       m.body = I18n.t(".messages.survey_reminder", locale: user.language || I18n.default_locale).gsub("{{survey_url}}", survey_url)
     end

--- a/app/jobs/send_waitlist_message_job.rb
+++ b/app/jobs/send_waitlist_message_job.rb
@@ -6,7 +6,6 @@ class SendWaitlistMessageJob < ApplicationJob
 
   def perform(user)
     message = Message.build do |m|
-      m.token = m.send(:generate_token)
       m.user = user
       m.body = substitute_variables(I18n.t(".messages.waitlist", locale: user.language), user)
     end

--- a/app/jobs/send_welcome_message_job.rb
+++ b/app/jobs/send_welcome_message_job.rb
@@ -6,7 +6,6 @@ class SendWelcomeMessageJob < ApplicationJob
 
   def perform(user)
     message = Message.build do |m|
-      m.token = m.send(:generate_token)
       m.user = user
       m.body = substitute_variables(I18n.t(".messages.welcome", locale: user.language), user)
     end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -20,19 +20,14 @@ class Message < ApplicationRecord
     end
   end
 
-  def generate_token
-    self.token = SecureRandom.alphanumeric(6)
-  end
-
   private
 
   def set_token
-    return unless new_record? && token.nil?
+    return unless new_record? && token.nil? && link.present?
 
-    token = generate_token
-
-    while Message.exists?(token:)
-      generate_token
+    loop do
+      self.token = SecureRandom.alphanumeric(6)
+      break unless Message.exists?(token: token)
     end
   end
 

--- a/db/migrate/20260513110612_allow_null_message_token.rb
+++ b/db/migrate/20260513110612_allow_null_message_token.rb
@@ -1,0 +1,5 @@
+class AllowNullMessageToken < ActiveRecord::Migration[8.1]
+  def change
+    change_column_null :messages, :token, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_13_082254) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_13_110612) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -213,7 +213,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_13_082254) do
     t.string "message_sid"
     t.datetime "sent_at"
     t.string "status"
-    t.string "token", null: false
+    t.string "token"
     t.datetime "updated_at", null: false
     t.bigint "user_id"
     t.index ["content_id"], name: "index_messages_on_content_id"

--- a/test/jobs/send_bilingual_message_job_test.rb
+++ b/test/jobs/send_bilingual_message_job_test.rb
@@ -7,7 +7,7 @@ class SendBilingualMessageJobTest < ActiveSupport::TestCase
   test "#perform sends message with default content" do
     user = create(:user, child_name: "Harry")
 
-    Message.any_instance.stubs(:generate_token).returns("ABC")
+    SecureRandom.stubs(:alphanumeric).returns("ABC")
 
     assert_enqueued_jobs 1, only: SendCustomMessageJob do
       SendBilingualMessageJob.new.perform(user)
@@ -22,7 +22,7 @@ class SendBilingualMessageJobTest < ActiveSupport::TestCase
     create(:group, language: "cy")
     user = create(:user, language: "cy", child_name: "Harry")
 
-    Message.any_instance.stubs(:generate_token).returns("ABC")
+    SecureRandom.stubs(:alphanumeric).returns("ABC")
 
     assert_enqueued_jobs 1, only: SendCustomMessageJob do
       SendBilingualMessageJob.new.perform(user)

--- a/test/jobs/send_message_job_test.rb
+++ b/test/jobs/send_message_job_test.rb
@@ -9,7 +9,7 @@ class SendMessageJobTest < ActiveSupport::TestCase
     content2 = create(:content, group: content.group, body: "Hi {{parent_name}}, here is a link for {{child_name}}: {{link}}")
     user = create(:user, last_content_id: content.id, first_name: "John", child_name: "Billy", group: content.group)
 
-    Message.any_instance.stubs(:generate_token).returns("123")
+    SecureRandom.stubs(:alphanumeric).returns("123")
 
     stub_successful_twilio_call("Hi John, here is a link for Billy: {{link}}".gsub("{{link}}", track_link_url("123")), user)
 
@@ -27,7 +27,7 @@ class SendMessageJobTest < ActiveSupport::TestCase
     content = create(:content, body: "Hi {{parent_name}}, here is a link for {{child_name}}: {{link}}")
     user = create(:user, first_name: "John", group: content.group)
 
-    Message.any_instance.stubs(:generate_token).returns("123")
+    SecureRandom.stubs(:alphanumeric).returns("123")
 
     stub_successful_twilio_call("Hi John, here is a link for your child: {{link}}".gsub("{{link}}", track_link_url("123")), user)
 
@@ -79,7 +79,7 @@ class SendMessageJobTest < ActiveSupport::TestCase
     user = build(:user, last_content_id: content.id, phone_number: "234")
     user.save(validate: false)
 
-    Message.any_instance.stubs(:generate_token).returns("123")
+    SecureRandom.stubs(:alphanumeric).returns("123")
 
     assert_no_changes -> { Message.count } do
       SendMessageJob.new.perform(user)
@@ -94,7 +94,7 @@ class SendMessageJobTest < ActiveSupport::TestCase
     user = create(:user, last_content_id: content.id, group: content.group)
     create(:survey, send_after_message_count: 1)
 
-    Message.any_instance.stubs(:generate_token).returns("123")
+    SecureRandom.stubs(:alphanumeric).returns("123")
     stub_successful_twilio_call("here is a link: #{track_link_url("123")}", user)
 
     assert_enqueued_jobs 1, only: SendSurveyJob do
@@ -109,7 +109,7 @@ class SendMessageJobTest < ActiveSupport::TestCase
     user.save(validate: false)
     create(:survey, send_after_message_count: 1)
 
-    Message.any_instance.stubs(:generate_token).returns("123")
+    SecureRandom.stubs(:alphanumeric).returns("123")
 
     assert_no_enqueued_jobs only: SendSurveyJob do
       SendMessageJob.new.perform(user)
@@ -123,7 +123,7 @@ class SendMessageJobTest < ActiveSupport::TestCase
     create(:message, user: user, content: content, created_at: 2.weeks.ago)
     create(:survey, title_en: "Offboarding")
 
-    Message.any_instance.stubs(:generate_token).returns("123")
+    SecureRandom.stubs(:alphanumeric).returns("123")
     stub_successful_twilio_call("here is a second link: #{track_link_url("123")}", user)
 
     freeze_time do
@@ -139,7 +139,7 @@ class SendMessageJobTest < ActiveSupport::TestCase
     user = create(:user, last_content_id: content.id, group: content.group, programme_length: 2, finished_content_at: nil)
     create(:message, user:, content:, created_at: 2.weeks.ago)
 
-    Message.any_instance.stubs(:generate_token).returns("123")
+    SecureRandom.stubs(:alphanumeric).returns("123")
     stub_successful_twilio_call("here is a second link: #{track_link_url("123")}", user)
 
     SendMessageJob.new.perform(user)
@@ -153,7 +153,7 @@ class SendMessageJobTest < ActiveSupport::TestCase
     user = create(:user, last_content_id: nil, group: content.group, programme_length: 2)
     create(:survey, title_en: "Offboarding")
 
-    Message.any_instance.stubs(:generate_token).returns("123")
+    SecureRandom.stubs(:alphanumeric).returns("123")
     stub_successful_twilio_call("here is a link: #{track_link_url("123")}", user)
 
     assert_no_enqueued_jobs only: OffboardingMessageJob do
@@ -167,7 +167,7 @@ class SendMessageJobTest < ActiveSupport::TestCase
     create(:message, user: user, content: content, created_at: 2.weeks.ago)
     create(:survey, title_en: "Offboarding")
 
-    Message.any_instance.stubs(:generate_token).returns("123")
+    SecureRandom.stubs(:alphanumeric).returns("123")
     stub_successful_twilio_call("here is a link: #{track_link_url("123")}", user)
 
     assert_no_enqueued_jobs only: OffboardingMessageJob do

--- a/test/models/message_test.rb
+++ b/test/models/message_test.rb
@@ -61,11 +61,19 @@ class MessageTest < ActiveSupport::TestCase
     assert_equal "Failed", message.admin_status
   end
 
-  test "#set_token sets the token" do
-    message = build(:message)
+  test "#set_token sets the token when the message has a link" do
+    message = build(:message, link: "https://example.com")
     assert_nil message.token
 
     message.save
     assert_not_nil message.token
+  end
+
+  test "#set_token leaves the token nil when the message has no link" do
+    message = build(:message, link: nil)
+    assert_nil message.token
+
+    message.save
+    assert_nil message.token
   end
 end


### PR DESCRIPTION
Tokens power /m/:token click tracking, so they're only meaningful for messages with a link. Make messages.token nullable, short-circuit set_token when link is blank, and fix a latent local-variable bug in set_token that broke under stubbed tests.