### PR TITLE
Only start waitlist users who click the link

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -52,6 +52,7 @@ class UsersController < ApplicationController
 
   def edit
     @step = params[:step].presence_in(STEPS) || STEPS.first
+    @user.update(contactable: true) unless @user.contactable?
   end
 
   def update
@@ -118,7 +119,8 @@ class UsersController < ApplicationController
   end
 
   def set_user
-    @user = User.find_by_token_for(:profile_token, params[:token])
+    @user = User.find_by_token_for(:profile_token, params[:token]) ||
+      User.find_by_token_for(:restart_token, params[:token])
     unless @user
       redirect_to root_path, notice: I18n.t("controllers.users.edit.notice")
     end

--- a/app/jobs/restart_messages_job.rb
+++ b/app/jobs/restart_messages_job.rb
@@ -4,8 +4,8 @@ class RestartMessagesJob < ApplicationJob
   queue_as :background
 
   def perform(user)
-    if user.update(contactable: true, restart_at: nil)
-      url = edit_user_url(user, token: user.generate_token_for(:profile_token))
+    if user.update(restart_at: nil)
+      url = edit_user_url(user, token: user.generate_token_for(:restart_token))
 
       message = Message.build(user: user, body: I18n.t(".messages.restart", locale: user.language).gsub("{{registration_form}}", url))
       SendCustomMessageJob.perform_later(message) if message.save

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,6 +23,7 @@ class User < ApplicationRecord
   before_validation :assign_group_by_language, if: -> { new_record? || language_changed? }
 
   generates_token_for :profile_token, expires_in: 15.minutes
+  generates_token_for :restart_token, expires_in: 2.days
   generates_token_for :survey_token
 
   scope :contactable, -> { where(contactable: true) }

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -42,6 +42,26 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     assert User.exists?(phone_number: "+447123456700")
   end
 
+  test "edit accepts a restart_token and marks the user contactable" do
+    user = create(:user, contactable: false)
+    token = user.generate_token_for(:restart_token)
+
+    get edit_user_url(user, token: token)
+
+    assert_response :success
+    assert user.reload.contactable
+  end
+
+  test "edit leaves an already-contactable user contactable" do
+    user = create(:user, contactable: true)
+    token = user.generate_token_for(:restart_token)
+
+    get edit_user_url(user, token: token)
+
+    assert_response :success
+    assert user.reload.contactable
+  end
+
   test "puts user on waitlist if child is under 9 months" do
     create(:group, language: "cy")
 

--- a/test/jobs/restart_messages_job_test.rb
+++ b/test/jobs/restart_messages_job_test.rb
@@ -14,7 +14,8 @@ class RestartMessagesJobTest < ActiveSupport::TestCase
     RestartMessagesJob.new.perform(user)
 
     assert_equal 1, Message.count
-    assert_equal true, user.contactable
+    assert_nil user.reload.restart_at
+    assert_equal false, user.contactable
   end
 
   test "#perform sends restart message in user's preferred language" do
@@ -27,6 +28,7 @@ class RestartMessagesJobTest < ActiveSupport::TestCase
     RestartMessagesJob.new.perform(user)
 
     assert_equal 1, Message.count
-    assert_equal true, user.contactable
+    assert_nil user.reload.restart_at
+    assert_equal false, user.contactable
   end
 end


### PR DESCRIPTION
Confirm that users definitely want to restart the process before making them contactable and sending them a message with the link to start.

This is to avoid making users contactable if they change their mind after joining the waitlist.

Token timeout is a bit longer to accommodate busy parents.