### PR TITLE
Extract `Registration` PORO from `UsersController#create`

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -23,26 +23,21 @@ class UsersController < ApplicationController
       return redirect_to root_path, notice: I18n.t("controllers.users.create.notice")
     end
 
-    @user = User.new(user_params)
-    @user.terms_agreed_at = Time.zone.now if @user.terms_agreed == "1"
+    registration = Registration.new(user_params: user_params, referrer_params: user_referrer_params)
 
-    if @user.save
-      @user.update_local_authority
-      UserReferrer.create(user_referrer_params) if user_referrer_params.values.any?(&:present?)
+    if registration.submit
+      user = registration.user
+      token = user.generate_token_for(:profile_token)
 
-      if @user.child_birthday > 9.months.ago.to_date
-        @user.put_on_waitlist
-        token = @user.generate_token_for(:profile_token)
-
-        redirect_to thank_you_user_path(@user, token:)
+      if user.on_waitlist?
+        redirect_to thank_you_user_path(user, token: token)
       else
-        token = @user.generate_token_for(:profile_token)
-
-        redirect_to edit_user_path(@user, token:)
+        redirect_to edit_user_path(user, token: token)
       end
     else
       @no_padding = true
       @hide_sidebar = true
+      @user = registration.user
 
       render :new, status: :unprocessable_content
     end

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -1,0 +1,27 @@
+class Registration
+  include ActiveModel::Model
+
+  attr_accessor :user_params, :referrer_params
+  attr_reader :user
+
+  def submit
+    @user = User.new(user_params)
+    @user.terms_agreed_at = Time.zone.now if @user.terms_agreed == "1"
+    return false unless @user.save
+
+    @user.update_local_authority
+    UserReferrer.create(referrer_params) if referrer_params.values.any?(&:present?)
+    schedule_next_step
+    true
+  end
+
+  def waitlisted?
+    @user.child_birthday > 9.months.ago.to_date
+  end
+
+  private
+
+  def schedule_next_step
+    waitlisted? ? @user.put_on_waitlist : nil
+  end
+end

--- a/test/models/registration_test.rb
+++ b/test/models/registration_test.rb
@@ -1,0 +1,131 @@
+require "test_helper"
+
+class RegistrationTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
+  setup { create(:group) }
+
+  def valid_user_params(overrides = {})
+    {
+      phone_number: "07712345678",
+      child_birthday: 18.months.ago.to_date,
+      postcode: "CF61 1ZH",
+      child_name: "Maya",
+      terms_agreed: "1",
+    }.merge(overrides)
+  end
+
+  def empty_referrer_params
+    {utm_source: nil, utm_medium: nil, utm_campaign: nil, utm_term: nil, utm_content: nil, gclid: nil}
+  end
+
+  test "#submit creates a user from user_params and returns true" do
+    registration = Registration.new(user_params: valid_user_params, referrer_params: empty_referrer_params)
+
+    assert_difference -> { User.count }, 1 do
+      assert registration.submit
+    end
+    assert registration.user.persisted?
+    assert_equal "+447712345678", registration.user.phone_number.delete(" ")
+  end
+
+  test "#submit returns false when the user cannot be saved" do
+    registration = Registration.new(user_params: valid_user_params(phone_number: nil), referrer_params: empty_referrer_params)
+
+    assert_no_difference -> { User.count } do
+      assert_not registration.submit
+    end
+  end
+
+  test "#submit exposes the unsaved user with errors when save fails" do
+    registration = Registration.new(user_params: valid_user_params(phone_number: nil), referrer_params: empty_referrer_params)
+    registration.submit
+
+    assert_not registration.user.persisted?
+    assert_includes registration.user.errors[:phone_number], "can't be blank"
+  end
+
+  test "#submit stamps terms_agreed_at to now when terms_agreed is '1'" do
+    freeze_time do
+      registration = Registration.new(user_params: valid_user_params(terms_agreed: "1"), referrer_params: empty_referrer_params)
+      registration.submit
+
+      assert_equal Time.zone.now, registration.user.terms_agreed_at
+    end
+  end
+
+  test "#submit does not stamp terms_agreed_at when terms_agreed is not '1'" do
+    registration = Registration.new(user_params: valid_user_params(terms_agreed: "0"), referrer_params: empty_referrer_params)
+    registration.submit
+
+    assert_nil registration.user.terms_agreed_at
+  end
+
+  test "#submit updates the user's local authority on success" do
+    LocationGeocoder.any_instance.stubs(:geocode).returns(Geokit::GeoLoc.new(state: "Cardiff", country_code: "Wales"))
+    registration = Registration.new(user_params: valid_user_params, referrer_params: empty_referrer_params)
+
+    registration.submit
+
+    assert_equal "Cardiff", registration.user.local_authority.name
+    assert_equal "Wales", registration.user.local_authority.country
+  end
+
+  test "#submit creates a UserReferrer when any referrer param is present" do
+    referrer_params = empty_referrer_params.merge(utm_source: "facebook", utm_campaign: "spring")
+    registration = Registration.new(user_params: valid_user_params, referrer_params: referrer_params)
+
+    assert_difference -> { UserReferrer.count }, 1 do
+      registration.submit
+    end
+    referrer = UserReferrer.last
+    assert_equal "facebook", referrer.utm_source
+    assert_equal "spring", referrer.utm_campaign
+  end
+
+  test "#submit does not create a UserReferrer when all referrer params are blank" do
+    registration = Registration.new(user_params: valid_user_params, referrer_params: empty_referrer_params)
+
+    assert_no_difference -> { UserReferrer.count } do
+      registration.submit
+    end
+  end
+
+  test "#submit puts the user on the waitlist when the child is too young" do
+    user_params = valid_user_params(child_birthday: 6.months.ago.to_date, skip_age_validation: "true")
+    registration = Registration.new(user_params: user_params, referrer_params: empty_referrer_params)
+
+    User.any_instance.expects(:put_on_waitlist).once
+
+    assert registration.submit
+  end
+
+  test "#submit does not put the user on the waitlist when the child is old enough" do
+    registration = Registration.new(user_params: valid_user_params, referrer_params: empty_referrer_params)
+
+    User.any_instance.expects(:put_on_waitlist).never
+
+    assert registration.submit
+  end
+
+  test "#waitlisted? is true when the child is younger than 9 months" do
+    registration = Registration.new(
+      user_params: valid_user_params(child_birthday: 6.months.ago.to_date, skip_age_validation: "true"),
+      referrer_params: empty_referrer_params,
+    )
+    User.any_instance.stubs(:put_on_waitlist)
+    registration.submit
+
+    assert registration.waitlisted?
+  end
+
+  test "#waitlisted? is false when the child is older than 9 months" do
+    registration = Registration.new(
+      user_params: valid_user_params(child_birthday: 12.months.ago.to_date),
+      referrer_params: empty_referrer_params,
+    )
+    registration.submit
+
+    assert_not registration.waitlisted?
+  end
+end


### PR DESCRIPTION
Simplifies the controller action and makes it easier to test the registration logic in isolation.

The `Registration` PORO will handle the creation of the user and any associated logic, while the controller will focus on handling the HTTP request and response.