### PR TITLE
Reduce the noise of the text/plain response

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -13,6 +13,10 @@ class UsersController < ApplicationController
   def new
     @no_padding = true
     @user = User.new
+
+    respond_to do |format|
+      format.html
+    end
   end
 
   def create


### PR DESCRIPTION
- Explicitly respond to HTML format. This will prevent Rails from including the text/plain response in the logs, making it easier to read and debug.