### PR TITLE
Turn response matcher into a model

### DIFF
--- a/app/jobs/response_matcher_job.rb
+++ b/app/jobs/response_matcher_job.rb
@@ -2,6 +2,6 @@ class ResponseMatcherJob < ApplicationJob
   queue_as :background
 
   def perform(message)
-    ResponseMatcherService.new(message).match_response
+    AutoResponseMatch.new(message: message).deliver
   end
 end

--- a/app/models/auto_response_match.rb
+++ b/app/models/auto_response_match.rb
@@ -1,24 +1,22 @@
-class ResponseMatcherService
-  def initialize(message)
-    @message = message
-    @user = message.user
-  end
+class AutoResponseMatch
+  include ActiveModel::Model
 
-  def match_response
-    responses = AutoResponse.where(trigger_phrase: normalized_message_body)
+  attr_accessor :message
+  delegate :user, to: :message
+
+  def deliver
+    responses = AutoResponse.where(trigger_phrase: normalized_body)
 
     if responses.any?
-      responses.each do |response|
-        process_response(response) and break if conditions_met?(response)
-      end
+      responses.each { |r| process_response(r) and break if conditions_met?(r) }
     elsif weekend?
-      send_message(I18n.t(".messages.out_of_hours_response", locale: @user.language))
+      send_message(I18n.t(".messages.out_of_hours_response", locale: user.language))
     end
   end
 
   private
 
-  def normalized_message_body
+  def normalized_body
     @message.body.downcase.strip
   end
 
@@ -32,12 +30,12 @@ class ResponseMatcherService
   end
 
   def send_message(body)
-    reply = Message.new(user: @user, body:)
+    reply = Message.new(user: user, body:)
     SendCustomMessageJob.perform_later(reply) if reply.save
   end
 
   def conditions_met?(response)
-    check_conditions(response.user_conditions, @user)
+    check_conditions(response.user_conditions, user)
   end
 
   def check_conditions(conditions, object)
@@ -51,7 +49,7 @@ class ResponseMatcherService
 
   def apply_updates(response)
     updates = JSON.parse(response.update_user)
-    updates.each { |key, value| update_attribute(key, value, @user) } if updates.any?
+    updates.each { |key, value| update_attribute(key, value, user) } if updates.any?
   end
 
   def update_attribute(key, value, object)

--- a/test/jobs/response_matcher_job_test.rb
+++ b/test/jobs/response_matcher_job_test.rb
@@ -3,11 +3,10 @@ require "test_helper"
 class ResponseMatcherJobTest < ActiveSupport::TestCase
   include ActiveJob::TestHelper
 
-  test "#perform delegates to ResponseMatcherService" do
+  test "#perform delegates to AutoResponseMatch" do
     message = create(:message)
-    service = mock
-    service.expects(:match_response).once
-    ResponseMatcherService.expects(:new).with(message).returns(service)
+
+    AutoResponseMatch.expects(:new).with(message: message).returns(mock(deliver: true))
 
     ResponseMatcherJob.new.perform(message)
   end

--- a/test/models/auto_response_match_test.rb
+++ b/test/models/auto_response_match_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class ResponseMatcherServiceTest < ActiveSupport::TestCase
+class AutoResponseMatchTest < ActiveSupport::TestCase
   include ActiveJob::TestHelper
 
   setup do
@@ -15,7 +15,7 @@ class ResponseMatcherServiceTest < ActiveSupport::TestCase
     message = build(:message, body: "stop", status: "received", user:)
 
     assert_no_changes Message.count do
-      ResponseMatcherService.new(message).match_response
+      AutoResponseMatch.new(message: message).deliver
     end
 
     refute user.contactable
@@ -26,7 +26,7 @@ class ResponseMatcherServiceTest < ActiveSupport::TestCase
     message = build(:message, body: "End", status: "received", user:)
 
     assert_enqueued_with(job: SendCustomMessageJob) do
-      ResponseMatcherService.new(message).match_response
+      AutoResponseMatch.new(message: message).deliver
     end
 
     refute user.contactable
@@ -38,7 +38,7 @@ class ResponseMatcherServiceTest < ActiveSupport::TestCase
     message = build(:message, body: "stop", status: "received", user:)
 
     assert_no_changes Message.count do
-      ResponseMatcherService.new(message).match_response
+      AutoResponseMatch.new(message: message).deliver
     end
 
     refute user.contactable
@@ -49,7 +49,7 @@ class ResponseMatcherServiceTest < ActiveSupport::TestCase
     message = build(:message, body: "start", status: "received", user:)
 
     assert_no_changes Message.count do
-      ResponseMatcherService.new(message).match_response
+      AutoResponseMatch.new(message: message).deliver
     end
 
     assert user.contactable
@@ -60,7 +60,7 @@ class ResponseMatcherServiceTest < ActiveSupport::TestCase
     message = build(:message, body: "yes", status: "received", user:)
 
     assert_enqueued_with(job: SendCustomMessageJob) do
-      ResponseMatcherService.new(message).match_response
+      AutoResponseMatch.new(message: message).deliver
     end
 
     assert_equal user.asked_for_feedback, false
@@ -72,7 +72,7 @@ class ResponseMatcherServiceTest < ActiveSupport::TestCase
     message = build(:message, body: "no", status: "received", user:)
 
     assert_enqueued_with(job: SendCustomMessageJob) do
-      ResponseMatcherService.new(message).match_response
+      AutoResponseMatch.new(message: message).deliver
     end
 
     assert_equal user.asked_for_feedback, false
@@ -84,7 +84,7 @@ class ResponseMatcherServiceTest < ActiveSupport::TestCase
     message = build(:message, body: "no", status: "received", user:)
 
     assert_no_changes Message.count do
-      ResponseMatcherService.new(message).match_response
+      AutoResponseMatch.new(message: message).deliver
     end
 
     assert_equal user.asked_for_feedback, false
@@ -94,14 +94,14 @@ class ResponseMatcherServiceTest < ActiveSupport::TestCase
     travel_to Time.current.beginning_of_week
     message = build(:message, body: "Hi there", status: "received")
 
-    ResponseMatcherService.new(message).match_response
+    AutoResponseMatch.new(message: message).deliver
 
     assert_no_changes Message.count do
-      ResponseMatcherService.new(message).match_response
+      AutoResponseMatch.new(message: message).deliver
     end
 
     assert_no_changes message.user do
-      ResponseMatcherService.new(message).match_response
+      AutoResponseMatch.new(message: message).deliver
     end
   end
 
@@ -111,10 +111,55 @@ class ResponseMatcherServiceTest < ActiveSupport::TestCase
     message = build(:message, body: "Hi there", status: "received")
 
     assert_enqueued_with(job: SendCustomMessageJob) do
-      ResponseMatcherService.new(message).match_response
+      AutoResponseMatch.new(message: message).deliver
     end
 
     assert_equal message.user.messages.last.body, "The team's working hours are 9am - 6pm, Monday to Friday. We'll get back to you as soon as we can."
+  end
+
+  test "should ignore leading and trailing whitespace in the body" do
+    user = create(:user, contactable: true)
+    message = build(:message, body: "  stop  ", status: "received", user:)
+
+    AutoResponseMatch.new(message: message).deliver
+
+    refute user.contactable
+  end
+
+  test "should use the user's language for the out-of-hours response" do
+    travel_to Time.current.end_of_week
+    create(:group, language: "cy")
+    user = create(:user, language: "cy")
+    message = build(:message, body: "Hi there", status: "received", user:)
+
+    assert_enqueued_with(job: SendCustomMessageJob) do
+      AutoResponseMatch.new(message: message).deliver
+    end
+
+    assert_equal "Oriau gwaith y tîm yw 9am–6pm, dydd Llun i ddydd Gwener. Byddwn yn ymateb cyn gynted ag y gallwn.", user.messages.last.body
+  end
+
+  test "should fire only the first matching response when multiple share a trigger phrase" do
+    create(:auto_response, trigger_phrase: "ping", response: "conditional reply", user_conditions: "{\"asked_for_feedback\": true}")
+    create(:auto_response, trigger_phrase: "ping", response: "unconditional reply", user_conditions: "{}")
+    user = create(:user, asked_for_feedback: false)
+    message = build(:message, body: "ping", status: "received", user:)
+
+    AutoResponseMatch.new(message: message).deliver
+
+    assert_equal "unconditional reply", user.messages.last.body
+  end
+
+  test "should not change the user when update_user is empty" do
+    create(:auto_response, trigger_phrase: "ping", response: "hi", update_user: "{}")
+    user = create(:user, contactable: true, asked_for_feedback: true)
+    message = build(:message, body: "ping", status: "received", user:)
+
+    AutoResponseMatch.new(message: message).deliver
+    user.reload
+
+    assert user.contactable
+    assert user.asked_for_feedback
   end
 
   test "doesn't fall over if updates aren't possible" do
@@ -126,7 +171,7 @@ class ResponseMatcherServiceTest < ActiveSupport::TestCase
     refute user.valid?
 
     assert_enqueued_with(job: SendCustomMessageJob) do
-      ResponseMatcherService.new(message).match_response
+      AutoResponseMatch.new(message: message).deliver
     end
 
     assert_equal user.messages.last.body, "You're all set to start receiving messages again!"


### PR DESCRIPTION
Thoughtbot's Claude audit suggested this as a service actually hiding as a model, which makes sense, so I've moved the logic into a model called AutoResponseMatch. The ResponseMatcherJob now delegates to this model, and the tests have been updated accordingly.